### PR TITLE
Add lukas-hetzenecker/home-assistant-remote integration

### DIFF
--- a/repositories/integration
+++ b/repositories/integration
@@ -98,5 +98,6 @@
   "Michsior14/ha-laser-egg",
   "gregoryduckworth/GoogleGeocode-HASS",
   "pinkywafer/Anniversaries",
-  "tmechen/ber_status"
+  "tmechen/ber_status",
+  "lukas-hetzenecker/home-assistant-remote"
 ]


### PR DESCRIPTION
Component to link multiple Home-Assistant instances together.