### PR TITLE
Proper tempfile call for backup path

### DIFF
--- a/custom_components/hacs/repositories/repository.py
+++ b/custom_components/hacs/repositories/repository.py
@@ -375,7 +375,7 @@ class HacsRepository(Hacs):
                 ):
                     persistent_directory = Backup(
                         f"{self.content.path.local}/{self.repository_manifest.persistent_directory}",
-                        tempfile.TemporaryFile() + "/hacs_persistent_directory/",
+                        tempfile.gettempdir() + "/hacs_persistent_directory/",
                     )
                     persistent_directory.create()
 


### PR DESCRIPTION
Solves #867 by using the system's temporary path as a string instead of creating a managed object in it.