### PR TITLE
Deprecate configuration for theme and python_script

### DIFF
--- a/.devcontainer/sample_configuration.yaml
+++ b/.devcontainer/sample_configuration.yaml
@@ -11,8 +11,6 @@ hacs:
   sidepanel_title: HACS
   sidepanel_icon: mdi:store
   appdaemon: true
-  python_script: true
-  theme: true
   options:
     experimental: true
     country: "NO"

--- a/custom_components/hacs/hacsbase/__init__.py
+++ b/custom_components/hacs/hacsbase/__init__.py
@@ -19,6 +19,7 @@ class HacsStatus:
     """HacsStatus."""
 
     startup = False
+    new = False
     background_task = False
     reloading_data = False
     upgrading_all = False
@@ -39,7 +40,6 @@ class System:
 
     status = HacsStatus()
     config_path = None
-    new = False
     ha_version = None
     disabled = False
     lovelace_mode = "storage"
@@ -141,7 +141,7 @@ class Hacs:
         if check:
             try:
                 await repository.registration()
-                if self.system.new:
+                if self.system.status.new:
                     repository.status.new = False
                 if repository.validate.errors:
                     self.common.skip.append(repository.information.full_name)
@@ -196,6 +196,7 @@ class Hacs:
         await self.recuring_tasks_installed()
 
         self.system.status.startup = False
+        self.system.status.new = False
         self.system.status.background_task = False
         self.hass.bus.async_fire("hacs/status", {})
         await self.data.async_write()

--- a/custom_components/hacs/hacsbase/data.py
+++ b/custom_components/hacs/hacsbase/data.py
@@ -69,7 +69,7 @@ class HacsData(Hacs):
         try:
             if not hacs and not repositories:
                 # Assume new install
-                self.system.new = True
+                self.system.status.new = True
                 return True
             self.logger.info("Restore started")
 

--- a/custom_components/hacs/hacsbase/update.py
+++ b/custom_components/hacs/hacsbase/update.py
@@ -1,6 +1,0 @@
-"""HACS Updater."""
-from . import Hacs
-
-
-class HacsUpdate(Hacs):
-    """Update class."""

--- a/custom_components/hacs/sensor.py
+++ b/custom_components/hacs/sensor.py
@@ -32,7 +32,10 @@ class HACSSensor(Entity):
         self.repositories = []
 
         for repository in hacs.repositories:
-            if repository.pending_upgrade:
+            if (
+                repository.pending_upgrade
+                and repository.category in hacs.common.categories
+            ):
                 self.repositories.append(repository)
         self._state = len(self.repositories)
 

--- a/custom_components/hacs/setup.py
+++ b/custom_components/hacs/setup.py
@@ -34,6 +34,15 @@ async def load_hacs_repository(hacs):
     return True
 
 
+def setup_extra_stores(hacs):
+    """Set up extra stores in HACS if enabled in Home Assistant."""
+    if "python_script" in hacs.hass.config.components:
+        hacs.common.categories.append("python_script")
+
+    if hacs.hass.services.services.get("frontend", {}).get("reload_themes") is not None:
+        hacs.common.categories.append("theme")
+
+
 def add_sensor(hacs):
     """Add sensor."""
     try:

--- a/custom_components/hacs/ws_api_handlers.py
+++ b/custom_components/hacs/ws_api_handlers.py
@@ -121,7 +121,7 @@ async def hacs_repositories(hass, connection, msg):
     repositories = Hacs().repositories
     content = []
     for repo in repositories:
-        if repo.category in Hacs().common.categories:
+        if repo.information.category in Hacs().common.categories:
             data = {
                 "additional_info": repo.information.additional_info,
                 "authors": repo.information.authors,
@@ -158,7 +158,7 @@ async def hacs_repositories(hass, connection, msg):
                 "version_or_commit": repo.display_version_or_commit,
             }
 
-        content.append(data)
+            content.append(data)
 
     connection.send_message(websocket_api.result_message(msg["id"], content))
 

--- a/custom_components/hacs/ws_api_handlers.py
+++ b/custom_components/hacs/ws_api_handlers.py
@@ -92,9 +92,6 @@ async def hacs_config(hass, connection, msg):
     content["frontend_compact"] = config.frontend_compact
     content["version"] = Hacs().version
     content["dev"] = config.dev
-    content["appdaemon"] = config.appdaemon
-    content["python_script"] = config.python_script
-    content["theme"] = config.theme
     content["country"] = config.country
     content["experimental"] = config.experimental
     content["categories"] = Hacs().common.categories
@@ -124,41 +121,42 @@ async def hacs_repositories(hass, connection, msg):
     repositories = Hacs().repositories
     content = []
     for repo in repositories:
-        data = {
-            "additional_info": repo.information.additional_info,
-            "authors": repo.information.authors,
-            "available_version": repo.display_available_version,
-            "beta": repo.status.show_beta,
-            "can_install": repo.can_install,
-            "category": repo.information.category,
-            "custom": repo.custom,
-            "default_branch": repo.information.default_branch,
-            "description": repo.information.description,
-            "domain": repo.manifest.get("domain"),
-            "file_name": repo.information.file_name,
-            "full_name": repo.information.full_name,
-            "hide": repo.status.hide,
-            "homeassistant": repo.repository_manifest.homeassistant,
-            "id": repo.information.uid,
-            "info": repo.information.info,
-            "installed_version": repo.display_installed_version,
-            "installed": repo.status.installed,
-            "javascript_type": repo.information.javascript_type,
-            "local_path": repo.content.path.local,
-            "main_action": repo.main_action,
-            "name": repo.display_name,
-            "new": repo.status.new,
-            "pending_upgrade": repo.pending_upgrade,
-            "releases": repo.releases.published_tags,
-            "selected_tag": repo.status.selected_tag,
-            "stars": repo.information.stars,
-            "state": repo.state,
-            "status_description": repo.display_status_description,
-            "status": repo.display_status,
-            "topics": repo.information.topics,
-            "updated_info": repo.status.updated_info,
-            "version_or_commit": repo.display_version_or_commit,
-        }
+        if repo.category in Hacs().common.categories:
+            data = {
+                "additional_info": repo.information.additional_info,
+                "authors": repo.information.authors,
+                "available_version": repo.display_available_version,
+                "beta": repo.status.show_beta,
+                "can_install": repo.can_install,
+                "category": repo.information.category,
+                "custom": repo.custom,
+                "default_branch": repo.information.default_branch,
+                "description": repo.information.description,
+                "domain": repo.manifest.get("domain"),
+                "file_name": repo.information.file_name,
+                "full_name": repo.information.full_name,
+                "hide": repo.status.hide,
+                "homeassistant": repo.repository_manifest.homeassistant,
+                "id": repo.information.uid,
+                "info": repo.information.info,
+                "installed_version": repo.display_installed_version,
+                "installed": repo.status.installed,
+                "javascript_type": repo.information.javascript_type,
+                "local_path": repo.content.path.local,
+                "main_action": repo.main_action,
+                "name": repo.display_name,
+                "new": repo.status.new,
+                "pending_upgrade": repo.pending_upgrade,
+                "releases": repo.releases.published_tags,
+                "selected_tag": repo.status.selected_tag,
+                "stars": repo.information.stars,
+                "state": repo.state,
+                "status_description": repo.display_status_description,
+                "status": repo.display_status,
+                "topics": repo.information.topics,
+                "updated_info": repo.status.updated_info,
+                "version_or_commit": repo.display_version_or_commit,
+            }
 
         content.append(data)
 


### PR DESCRIPTION
**Don't panic if you see this!**

Themes and python scripts will still be supported, it's just the configuration that will be deprecated since HACS can ask HA if the are enabled there is no use of having the configuration there.