### PR TITLE
Catch all exceptions from get_ratelimit

### DIFF
--- a/custom_components/hacs/helpers/remaining_github_calls.py
+++ b/custom_components/hacs/helpers/remaining_github_calls.py
@@ -6,7 +6,7 @@ async def remaining(github):
     """Helper to calculate the remaining calls to github."""
     try:
         ratelimits = await github.get_ratelimit()
-    except Exception:  # pylint: disable=broad-except
+    except:  # pylint: disable=broad-except
         return 0
     if ratelimits.remaining:
         return int(ratelimits.remaining)


### PR DESCRIPTION
My home assistant instance became unresponsive today with the following in the log:
```
Traceback (most recent call last):,
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main,
    "__main__", mod_spec),
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code,
    exec(code, run_globals),
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 350, in <module>,
    sys.exit(main()),
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 342, in main,
    exit_code = asyncio.run(setup_and_run_hass(config_dir, args), debug=args.debug),
  File "/usr/local/lib/python3.7/asyncio/runners.py", line 43, in run,
    return loop.run_until_complete(main),
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 574, in run_until_complete,
    self.run_forever(),
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 541, in run_forever,
    self._run_once(),
  File "/usr/local/lib/python3.7/asyncio/base_events.py", line 1786, in _run_once,
    handle._run(),
  File "/usr/local/lib/python3.7/asyncio/events.py", line 88, in _run,
    self._context.run(self._callback, *self._args),
  File "/config/custom_components/hacs/hacsbase/__init__.py", line 273, in prosess_queue,
    can_update = await get_fetch_updates_for(self.github),
  File "/config/custom_components/hacs/helpers/remaining_github_calls.py", line 19, in get_fetch_updates_for,
    limit = await remaining(github),
  File "/config/custom_components/hacs/helpers/remaining_github_calls.py", line 8, in remaining,
    ratelimits = await github.get_ratelimit(),
  File "/usr/local/lib/python3.7/site-packages/backoff/_async.py", line 133, in retry,
    ret = await target(*args, **kwargs),
  File "/usr/local/lib/python3.7/site-packages/aiogithubapi/aiogithub.py", line 148, in get_ratelimit,
    raise AIOGitHubException(f"GitHub returned {response.status} for {url}"),
aiogithubapi.exceptions.AIOGitHubException: GitHub returned 502 for https://api.github.com/rate_limit,
```

Since AIOGitHubException extends BaseException and not Exception, it was not caught in remaining_github_calls.py .
I propose to change this to a catch-all.