### PR TITLE
Revert the UI back to use the old way

### DIFF
--- a/custom_components/hacs/manifest.json
+++ b/custom_components/hacs/manifest.json
@@ -14,7 +14,7 @@
     "aiofiles==0.5.0",
     "aiogithubapi==1.0.4",
     "backoff==1.10.0",
-    "hacs_frontend==20200522122100",
+    "hacs_frontend==20200522214300",
     "integrationhelper==0.2.2",
     "semantic_version==2.8.5",
     "queueman==0.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiogithubapi==1.0.4
 aiohttp>=3.6.1,<4.0
 attrs==19.3.0
 backoff==1.10.0
-hacs_frontend==20200522122100
+hacs_frontend==20200522214300
 integrationhelper==0.2.2
 PyGithub==1.51
 pytest-asyncio==0.12.0


### PR DESCRIPTION
Due to popular? opinion I'm making this PR to bring back the old UI.
![image](https://user-images.githubusercontent.com/15093472/82704510-fdb7a880-9c75-11ea-951c-06a7c48041af.png)

This will also bring back all the issues it was with that UI, and I will only do bugfixes from this point in the UI, you can still add feature requests but I will not be adding them.

The reasons I changed it in the first place:
- It was falling behind HA, in how it felt to use and I wanted to bring it closer.
- It has performance issues, and those will continue to grow with each new repository that is added.
- The codebase are hard to maintain, there are elements all over the place that somehow ties together.

There has been a great number of feature requests added for the new UI, I will pause the work on them until this is decided.

closes #1226, closes #1225, closes #1224, closes #1223, closes #1219, closes #1218, closes #1216, closes #1213, closes #1212, closes #1210, closes #1208, closes #1196, closes #1193, closes #1189, closes #1188, closes #1185, closes #1183

Frankly, I'm just too tired with all the negativity...

So add your votes on this description:
👍 Merge this.
👎 Keep working on the new UI.