### PR TITLE
Add frontend_repo_url

### DIFF
--- a/custom_components/hacs/__init__.py
+++ b/custom_components/hacs/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryNotReady, ServiceNotFound
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.event import async_call_later
 
-from custom_components.hacs.configuration_schema import hacs_config_combined
+from custom_components.hacs.configuration_schema import hacs_config_combined, FRONTEND_REPO, FRONTEND_REPO_URL
 from custom_components.hacs.const import DOMAIN, ELEMENT_TYPES, STARTUP, VERSION
 from custom_components.hacs.constrains import check_constrains
 from custom_components.hacs.helpers.remaining_github_calls import get_fetch_updates_for
@@ -42,10 +42,17 @@ async def async_setup(hass, config):
         return True
     if hacs.configuration and hacs.configuration.config_type == "flow":
         return True
+
+    configuration = config[DOMAIN]
+
+    if configuration.get(FRONTEND_REPO) and configuration.get(FRONTEND_REPO_URL):
+        hacs.logger.error("Could not setup HACS, set only one of frontend_repo and frontend_repo_url.")
+        return False
+
     hass.data[DOMAIN] = config
     hacs.hass = hass
     hacs.session = async_create_clientsession(hass)
-    hacs.configuration = Configuration.from_dict(config[DOMAIN])
+    hacs.configuration = Configuration.from_dict(configuration)
     hacs.configuration.config = config
     hacs.configuration.config_type = "yaml"
     await startup_wrapper_for_yaml()

--- a/custom_components/hacs/__init__.py
+++ b/custom_components/hacs/__init__.py
@@ -46,7 +46,8 @@ async def async_setup(hass, config):
     configuration = config[DOMAIN]
 
     if configuration.get(FRONTEND_REPO) and configuration.get(FRONTEND_REPO_URL):
-        hacs.logger.error("Could not setup HACS, set only one of frontend_repo and frontend_repo_url.")
+        hacs.logger.critical("Could not setup HACS, set only one of ('frontend_repo', 'frontend_repo_url)")
+
         return False
 
     hass.data[DOMAIN] = config

--- a/custom_components/hacs/config_flow.py
+++ b/custom_components/hacs/config_flow.py
@@ -92,5 +92,6 @@ class HacsOptionsFlowHandler(config_entries.OptionsFlow):
         else:
             schema = hacs_config_option_schema(self.config_entry.options)
             del schema["frontend_repo"]
+            del schema["frontend_repo_url"]
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))

--- a/custom_components/hacs/configuration_schema.py
+++ b/custom_components/hacs/configuration_schema.py
@@ -8,6 +8,7 @@ TOKEN = "token"
 SIDEPANEL_TITLE = "sidepanel_title"
 SIDEPANEL_ICON = "sidepanel_icon"
 FRONTEND_REPO = "frontend_repo"
+FRONTEND_REPO_URL = "frontend_repo_url"
 APPDAEMON = "appdaemon"
 NETDAEMON = "netdaemon"
 
@@ -42,6 +43,7 @@ def hacs_config_option_schema(options: dict = {}) -> dict:
             SIDEPANEL_ICON: "hacs:hacs",
             SIDEPANEL_TITLE: "HACS",
             FRONTEND_REPO: "",
+            FRONTEND_REPO_URL: "",
         }
     return {
         vol.Optional(SIDEPANEL_TITLE, default=options.get(SIDEPANEL_TITLE)): str,
@@ -53,6 +55,7 @@ def hacs_config_option_schema(options: dict = {}) -> dict:
         vol.Optional(DEBUG, default=options.get(DEBUG)): bool,
         vol.Optional(EXPERIMENTAL, default=options.get(EXPERIMENTAL)): bool,
         vol.Optional(FRONTEND_REPO, default=options.get(FRONTEND_REPO)): str,
+        vol.Optional(FRONTEND_REPO_URL, default=options.get(FRONTEND_REPO_URL)): str,
     }
 
 

--- a/custom_components/hacs/hacsbase/configuration.py
+++ b/custom_components/hacs/hacsbase/configuration.py
@@ -21,6 +21,7 @@ class Configuration:
     frontend_mode: str = "Grid"
     frontend_compact: bool = False
     frontend_repo: str = ""
+    frontend_repo_url: str = ""
     options: dict = {}
     onboarding_done: bool = False
     plugin_path: str = "www/community/"


### PR DESCRIPTION
## Overview

Similar to `frontend_repo`, adds a new option - `frontend_repo_url` that loads the main.js file from a remote resource.

Adds validation that only one of `frontend_repo` and `frontend_repo_url` is provided.

Example configuration:
```yaml
hacs:
  token: !secret hacs_dev_token
  appdaemon: true
  netdaemon: true
  frontend_repo_url: http://192.168.0.100:5000
```

It is expected that the server at 192.168.0.100 serves the built hacs/frontend `main.js` file: `http://192.168.0.100:5000/main.js`.