### PR TITLE
Reduce startup time by limiting the usage of .lower()

### DIFF
--- a/custom_components/hacs/hacsbase/hacs.py
+++ b/custom_components/hacs/hacsbase/hacs.py
@@ -111,9 +111,10 @@ class Hacs(HacsHelpers):
 
     def get_by_name(self, repository_full_name):
         """Get repository by full_name."""
+        repository_full_name_lower = repository_full_name.lower()
         try:
             for repository in self.repositories:
-                if repository.data.full_name.lower() == repository_full_name.lower():
+                if repository.data.full_name_lower == repository_full_name_lower:
                     return repository
         except (Exception, BaseException):  # pylint: disable=broad-except
             pass

--- a/custom_components/hacs/hacsbase/hacs.py
+++ b/custom_components/hacs/hacsbase/hacs.py
@@ -111,8 +111,8 @@ class Hacs(HacsHelpers):
 
     def get_by_name(self, repository_full_name):
         """Get repository by full_name."""
-        repository_full_name_lower = repository_full_name.lower()
         try:
+            repository_full_name_lower = repository_full_name.lower()
             for repository in self.repositories:
                 if repository.data.full_name_lower == repository_full_name_lower:
                     return repository

--- a/custom_components/hacs/helpers/classes/repository.py
+++ b/custom_components/hacs/helpers/classes/repository.py
@@ -65,6 +65,7 @@ class RepositoryInformation:
     description = ""
     state = None
     full_name = None
+    full_name_lower = None
     file_name = None
     javascript_type = None
     homeassistant_version = None

--- a/custom_components/hacs/repositories/appdaemon.py
+++ b/custom_components/hacs/repositories/appdaemon.py
@@ -14,6 +14,7 @@ class HacsAppdaemon(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.category = "appdaemon"
         self.content.path.local = self.localpath
         self.content.path.remote = "apps"

--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -19,6 +19,7 @@ class HacsIntegration(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.category = "integration"
         self.content.path.remote = "custom_components"
         self.content.path.local = self.localpath

--- a/custom_components/hacs/repositories/netdaemon.py
+++ b/custom_components/hacs/repositories/netdaemon.py
@@ -15,6 +15,7 @@ class HacsNetdaemon(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.category = "netdaemon"
         self.content.path.local = self.localpath
         self.content.path.remote = "apps"

--- a/custom_components/hacs/repositories/plugin.py
+++ b/custom_components/hacs/repositories/plugin.py
@@ -14,6 +14,7 @@ class HacsPlugin(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.file_name = None
         self.data.category = "plugin"
         self.information.javascript_type = None

--- a/custom_components/hacs/repositories/python_script.py
+++ b/custom_components/hacs/repositories/python_script.py
@@ -15,6 +15,7 @@ class HacsPythonScript(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.category = "python_script"
         self.content.path.remote = "python_scripts"
         self.content.path.local = self.localpath

--- a/custom_components/hacs/repositories/theme.py
+++ b/custom_components/hacs/repositories/theme.py
@@ -13,6 +13,7 @@ class HacsTheme(HacsRepository):
         """Initialize."""
         super().__init__()
         self.data.full_name = full_name
+        self.data.full_name_lower = full_name.lower()
         self.data.category = "theme"
         self.content.path.remote = "themes"
         self.content.path.local = self.localpath

--- a/tests/dummy_repository.py
+++ b/tests/dummy_repository.py
@@ -28,6 +28,7 @@ def dummy_repository_base(repository=None):
     repository.hacs.system.config_path = tempfile.gettempdir()
     repository.logger = getLogger("test.test")
     repository.data.full_name = "test/test"
+    repository.data.full_name_lower = "test/test"
     repository.data.domain = "test"
     repository.data.last_version = "3"
     repository.data.selected_tag = "3"

--- a/tests/hacsbase/test_hacs.py
+++ b/tests/hacsbase/test_hacs.py
@@ -19,6 +19,7 @@ async def test_hacs(tmpdir):
 
     hacs.repositories = [repo]
     assert hacs.get_by_id("1337").data.full_name == "test/test"
+    assert hacs.get_by_id("1337").data.full_name_lower == "test/test"
 
     hacs.repositories = [None]
     assert hacs.get_by_name(None) is None

--- a/tests/hacsbase/test_hacsbase_data.py
+++ b/tests/hacsbase/test_hacsbase_data.py
@@ -44,4 +44,3 @@ async def test_hacs_data_restore(tmpdir):
     hacs.hass = HomeAssistant()
     hacs.hass.config.config_dir = tmpdir
     await data.restore()
-

--- a/tests/helpers/misc/test_get_repository_name.py
+++ b/tests/helpers/misc/test_get_repository_name.py
@@ -12,6 +12,7 @@ ELEMENT_TYPES = ELEMENT_TYPES + ["appdaemon", "python_script", "theme"]
 def test_everything():
     repository = dummy_repository_base()
     repository.data.full_name = "test/TEST-REPOSITORY-NAME"
+    repository.data.full_name_lower = "test/TEST-REPOSITORY-NAME".lower()
     repository.repository_manifest = HacsManifest.from_dict(
         {"name": "TEST-HACS_MANIFEST"}
     )
@@ -27,6 +28,7 @@ def test_integration_manifest():
     repository = dummy_repository_base()
     repository.data.category = "integration"
     repository.data.full_name = "test/TEST-REPOSITORY-NAME"
+    repository.data.full_name_lower = "test/TEST-REPOSITORY-NAME".lower()
     repository.repository_manifest = HacsManifest.from_dict({})
     repository.integration_manifest = {"name": "TEST-MANIFEST"}
 
@@ -37,6 +39,7 @@ def test_integration_manifest():
 def test_repository_name():
     repository = dummy_repository_base()
     repository.data.full_name = "test/TEST-REPOSITORY-NAME"
+    repository.data.full_name_lower = "test/TEST-REPOSITORY-NAME".lower()
     repository.repository_manifest = HacsManifest.from_dict({})
 
     name = get_repository_name(repository)

--- a/tests/repositories/helpers/test_properties.py
+++ b/tests/repositories/helpers/test_properties.py
@@ -12,6 +12,7 @@ def test_repository_helpers_properties_custom():
     repository = HacsRepository()
 
     repository.data.full_name = "test/test"
+    repository.data.full_name_lower = "test/test"
     assert repository.custom
 
     repository.data.id = 1337
@@ -22,6 +23,7 @@ def test_repository_helpers_properties_custom():
     assert repository.custom
 
     repository.data.full_name = "hacs/integration"
+    repository.data.full_name_lower = "hacs/integration"
     assert not repository.custom
 
 

--- a/tests/repositories/test_core.py
+++ b/tests/repositories/test_core.py
@@ -7,6 +7,7 @@ def test_hacs_repository_core_mostly_defaults():
     repository = HacsRepository()
 
     repository.data.full_name = "developer/repository"
+    repository.data.full_name_lower = "developer/repository"
     repository.data.default_branch = "master"
     repository.data.description = "Awesome GitHub repository"
 


### PR DESCRIPTION
This reduced the total time to call `async_get_category_repositories` and `startup_tasks` by ~41%.

Ideally we would have an index by name instead so we could quickly lookup the repo by name as this is still a bit of a bottleneck.
