### PR TITLE
Fix path separator issue on Windows.

### DIFF
--- a/custom_components/hacs/validate/__init__.py
+++ b/custom_components/hacs/validate/__init__.py
@@ -9,7 +9,7 @@ from custom_components.hacs.share import SHARE, get_hacs
 def _initialize_rules():
     rules = glob.glob(join(dirname(__file__), "**/*.py"))
     for rule in rules:
-        rule = rule.replace (sep, "/")
+        rule = rule.replace(sep, "/")
         rule = rule.split("custom_components/hacs")[-1]
         rule = f"custom_components/hacs{rule}".replace("/", ".")[:-3]
         importlib.import_module(rule)


### PR DESCRIPTION
Fix an issue with path separators on Windows systems by replacing
backslashes with forward slashes.

Fixes #1450 