### PR TITLE
Rename entry to entry_type in device_info

### DIFF
--- a/custom_components/hacs/sensor.py
+++ b/custom_components/hacs/sensor.py
@@ -28,7 +28,7 @@ class HACSDevice(Entity):
             "manufacturer": "hacs.xyz",
             "model": "",
             "sw_version": VERSION,
-            "type": "service",
+            "entry_type": "service",
         }
 
 


### PR DESCRIPTION
In the `device_info` property, there should be `"entry_type": "service"` instead of the `"type": "service"` element. Look here: https://github.com/home-assistant/core/blob/dev/homeassistant/components/config/device_registry.py#L74