### PR TITLE
Make sure event path exists first

### DIFF
--- a/action/action.py
+++ b/action/action.py
@@ -45,7 +45,7 @@ def error(error: str):
 
 
 def get_event_data():
-    if GITHUB_EVENT_PATH is None:
+    if GITHUB_EVENT_PATH is None or not os.path.exists(GITHUB_EVENT_PATH):
         return {}
     with open(GITHUB_EVENT_PATH) as ev:
         return json.loads(ev.read())


### PR DESCRIPTION
Just in case that the event path was passed in, but it doesn't exist, this checks it exists first. Better safe then sorry.