### PR TITLE
Significantly reduce the number of executor jobs on startup

### DIFF
--- a/custom_components/hacs/helpers/functions/store.py
+++ b/custom_components/hacs/helpers/functions/store.py
@@ -5,12 +5,17 @@ from homeassistant.helpers.json import JSONEncoder
 from custom_components.hacs.const import VERSION_STORAGE
 
 
-async def async_load_from_store(hass, key):
-    """Load the retained data from store and return de-serialized data."""
+def get_store_for_key(hass, key):
+    """Create a Store object for the key."""
+    key = key if "/" in key else f"hacs.{key}"
     from homeassistant.helpers.storage import Store
 
-    key = key if "/" in key else f"hacs.{key}"
-    store = Store(hass, VERSION_STORAGE, key, encoder=JSONEncoder)
+    return Store(hass, VERSION_STORAGE, key, encoder=JSONEncoder)
+
+
+async def async_load_from_store(hass, key):
+    """Load the retained data from store and return de-serialized data."""
+    store = get_store_for_key(hass, key)
     restored = await store.async_load()
     if restored is None:
         return {}
@@ -19,18 +24,11 @@ async def async_load_from_store(hass, key):
 
 async def async_save_to_store(hass, key, data):
     """Generate dynamic data to store and save it to the filesystem."""
-    from homeassistant.helpers.storage import Store
-
-    key = key if "/" in key else f"hacs.{key}"
-    store = Store(hass, VERSION_STORAGE, key, encoder=JSONEncoder)
-    await store.async_save(data)
+    await get_store_for_key(hass, key).async_save(data)
 
 
 async def async_remove_store(hass, key):
     """Remove a store element that should no longer be used"""
-    from homeassistant.helpers.storage import Store
-
     if "/" not in key:
         return
-    store = Store(hass, VERSION_STORAGE, key, encoder=JSONEncoder)
-    await store.async_remove()
+    await get_store_for_key(hass, key).async_remove()


### PR DESCRIPTION
Do not attempt to load stores that do not exist
as it overloads the executor

Cut at least ~25MiB of memory off many instances.  

On some it was even better because previously
they had 62 peak SyncWorkers and now have 11