### PR TITLE
Remove double check for .gz as aiohttp already does it

### DIFF
--- a/custom_components/hacs/webresponses/category.py
+++ b/custom_components/hacs/webresponses/category.py
@@ -14,10 +14,6 @@ async def async_serve_category_file(request, requested_file):
         else:
             servefile = f"{hacs.core.config_path}/www/community/{requested_file}"
 
-        # Serve .gz if it exist
-        if await async_path_exsist(f"{servefile}.gz"):
-            servefile += ".gz"
-
         if await async_path_exsist(servefile):
             logger.debug(f"Serving {requested_file} from {servefile}")
             response = web.FileResponse(servefile)

--- a/custom_components/hacs/webresponses/frontend.py
+++ b/custom_components/hacs/webresponses/frontend.py
@@ -37,8 +37,6 @@ async def async_serve_frontend(requested_file):
         servefile = f"{hacs.configuration.frontend_repo}/hacs_frontend/{requested}"
     else:
         servefile = f"{locate_dir()}/{requested}"
-        if await async_path_exsist(f"{servefile}.gz"):
-            servefile += ".gz"
 
     if servefile is None or not await async_path_exsist(servefile):
         return web.Response(status=404)


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web_fileresponse.py#L239

Verified the .gz is still served

`strace -p 13137 -f -s4096 -e trace=open`
`[pid 13187] open("/config/www/community/search-card/search-card.js.gz", O_RDONLY|O_CLOEXEC) = 35`