### PR TITLE
Remove double write on startup

### DIFF
--- a/custom_components/hacs/hacsbase/hacs.py
+++ b/custom_components/hacs/hacsbase/hacs.py
@@ -167,7 +167,6 @@ class Hacs(HacsBase, HacsHelpers):
         self.status.background_task = False
         self.hass.bus.async_fire("hacs/status", {})
         await self.async_set_stage(HacsStage.RUNNING)
-        await self.data.async_write()
 
     async def handle_critical_repositories_startup(self):
         """Handled critical repositories during startup."""


### PR DESCRIPTION
recurring_tasks_installed and startup_tasks were both
writing the data.

Noticed while cleaning up https://github.com/home-assistant/core/pull/42576