### PR TITLE
Cache underlying can_install version checks

### DIFF
--- a/custom_components/hacs/helpers/functions/misc.py
+++ b/custom_components/hacs/helpers/functions/misc.py
@@ -27,7 +27,7 @@ def get_repository_name(repository) -> str:
     )
 
 
-@lru_cache
+@lru_cache(maxsize=1024)
 def version_left_higher_then_right(new: str, old: str) -> bool:
     """Return a bool if source is newer than target, will also be true if identical."""
     if not isinstance(new, str) or not isinstance(old, str):

--- a/custom_components/hacs/helpers/functions/misc.py
+++ b/custom_components/hacs/helpers/functions/misc.py
@@ -1,6 +1,7 @@
 """Helper functions: misc"""
 import re
 import semantic_version
+from functools import lru_cache
 
 RE_REPOSITORY = re.compile(
     r"(?:(?:.*github.com.)|^)([A-Za-z0-9-]+\/[\w.-]+?)(?:(?:\.git)?|(?:[^\w.-].*)?)$"
@@ -26,6 +27,7 @@ def get_repository_name(repository) -> str:
     )
 
 
+@lru_cache
 def version_left_higher_then_right(new: str, old: str) -> bool:
     """Return a bool if source is newer than target, will also be true if identical."""
     if not isinstance(new, str) or not isinstance(old, str):

--- a/tests/helpers/misc/test_version_is_newer_than_version.py
+++ b/tests/helpers/misc/test_version_is_newer_than_version.py
@@ -27,4 +27,4 @@ def test_wierd_stuff():
     assert version_left_higher_then_right("1.0.0", "1.0.0rc0")
     assert not version_left_higher_then_right(None, "1.0.0rc0")
     assert not version_left_higher_then_right(1.0, "1.0.0rc0")
-    assert not version_left_higher_then_right({}, "1.0.0rc0")
+    assert not version_left_higher_then_right("", "1.0.0rc0")

--- a/tests/helpers/misc/test_version_is_newer_than_version.py
+++ b/tests/helpers/misc/test_version_is_newer_than_version.py
@@ -27,4 +27,4 @@ def test_wierd_stuff():
     assert version_left_higher_then_right("1.0.0", "1.0.0rc0")
     assert not version_left_higher_then_right(None, "1.0.0rc0")
     assert not version_left_higher_then_right(1.0, "1.0.0rc0")
-    assert not version_left_higher_then_right("", "1.0.0rc0")
+    assert not version_left_higher_then_right("0", "1.0.0rc0")

--- a/tests/repositories/helpers/test_properties.py
+++ b/tests/repositories/helpers/test_properties.py
@@ -16,7 +16,7 @@ def test_repository_helpers_properties_custom():
     assert repository.custom
 
     repository.data.id = 1337
-    repository.hacs.common.default.append(repository.data.id)
+    repository.hacs.common.default.append(str(repository.data.id))
     assert not repository.custom
 
     repository.hacs.common.default = []

--- a/tests/repositories/helpers/test_properties.py
+++ b/tests/repositories/helpers/test_properties.py
@@ -16,7 +16,7 @@ def test_repository_helpers_properties_custom():
     assert repository.custom
 
     repository.data.id = 1337
-    repository.hacs.common.default.append(str(repository.data.id))
+    repository.hacs.common.default.append(repository.data.id)
     assert not repository.custom
 
     repository.hacs.common.default = []


### PR DESCRIPTION
`can_installed` kept showing up in the profile so it seemed like we should cache version comparison.
