### PR TITLE
Cleanup custom check overhead

### DIFF
--- a/custom_components/hacs/helpers/properties/custom.py
+++ b/custom_components/hacs/helpers/properties/custom.py
@@ -6,7 +6,7 @@ class RepositoryPropertyCustom(ABC):
     @property
     def custom(self):
         """Return flag if the repository is custom."""
-        if str(self.data.id) in [str(x) for x in self.hacs.common.default]:
+        if str(self.data.id) in self.hacs.common.default:
             return False
         if self.data.full_name == "hacs/integration":
             return False

--- a/tests/repositories/helpers/test_properties.py
+++ b/tests/repositories/helpers/test_properties.py
@@ -16,7 +16,7 @@ def test_repository_helpers_properties_custom():
     assert repository.custom
 
     repository.data.id = 1337
-    repository.hacs.common.default.append(repository.data.id)
+    repository.hacs.common.default.append(str(repository.data.id))
     assert not repository.custom
 
     repository.hacs.common.default = []


### PR DESCRIPTION
hacs.hacsbase.hacs always ensures these are strings
so we should not need to recheck