### PR TITLE
Implement etag support for category files

### DIFF
--- a/custom_components/hacs/helpers/functions/file_etag.py
+++ b/custom_components/hacs/helpers/functions/file_etag.py
@@ -1,0 +1,21 @@
+# pylint: disable=missing-class-docstring,missing-module-docstring,missing-function-docstring,no-member
+import os
+
+from custom_components.hacs.share import get_hacs
+from fnvhash import fnv1a_32
+from pathlib import Path
+
+
+def get_etag(path) -> bool:
+    file_path = Path(path)
+    if not file_path.exists():
+        return None
+    return fnv1a_32(file_path.read_bytes())
+
+
+async def async_get_etag(path) -> bool:
+    hass = get_hacs().hass
+    fnv = await hass.async_add_executor_job(get_etag, path)
+    if fnv is None:
+        return None
+    return str(hex(fnv))

--- a/custom_components/hacs/manifest.json
+++ b/custom_components/hacs/manifest.json
@@ -18,7 +18,7 @@
     "aiofiles>=0.5.0",
     "aiogithubapi>=2.0.0<3.0.0",
     "backoff>=1.10.0",
-    "fnvhash==0.1.0",
+    "fnvhash>=0.1.0<1.0.0",
     "hacs_frontend==202011221222",
     "semantic_version>=2.8.5",
     "queueman==0.5"

--- a/custom_components/hacs/manifest.json
+++ b/custom_components/hacs/manifest.json
@@ -18,6 +18,7 @@
     "aiofiles>=0.5.0",
     "aiogithubapi>=2.0.0<3.0.0",
     "backoff>=1.10.0",
+    "fnvhash==0.1.0",
     "hacs_frontend==202011151903",
     "semantic_version>=2.8.5",
     "queueman==0.5"

--- a/custom_components/hacs/webresponses/category.py
+++ b/custom_components/hacs/webresponses/category.py
@@ -2,6 +2,8 @@ from aiohttp import web
 
 from custom_components.hacs.helpers.functions.logger import getLogger
 from custom_components.hacs.helpers.functions.path_exsist import async_path_exsist
+from custom_components.hacs.helpers.functions.file_etag import async_get_etag
+
 from custom_components.hacs.share import get_hacs
 
 _LOGGER = getLogger()
@@ -9,31 +11,83 @@ _LOGGER = getLogger()
 
 async def async_serve_category_file(request, requested_file):
     hacs = get_hacs()
+    response = None
+
     try:
         if requested_file.startswith("themes/"):
             servefile = f"{hacs.core.config_path}/{requested_file}"
+            response = await async_serve_static_file(request, servefile, requested_file)
         else:
             servefile = f"{hacs.core.config_path}/www/community/{requested_file}"
-
-        if await async_path_exsist(servefile):
-            _LOGGER.debug("Serving %s from %s", requested_file, servefile)
-            response = web.FileResponse(servefile)
-            if requested_file.startswith("themes/"):
-                response.headers["Cache-Control"] = "public, max-age=2678400"
-            else:
-                response.headers["Cache-Control"] = "no-store, max-age=0"
-                response.headers["Pragma"] = "no-store"
-            return response
-        else:
-            _LOGGER.error(
-                "%s tried to request '%s' but the file does not exist",
-                request.remote,
-                servefile,
+            response = await async_serve_static_file_with_etag(
+                request, servefile, requested_file
             )
+    except (Exception, BaseException):
+        _LOGGER.exception("Error trying to serve %s", requested_file)
 
-    except (Exception, BaseException) as exception:
-        _LOGGER.debug(
-            "there was an issue trying to serve %s - %s", requested_file, exception
-        )
+    if response is not None:
+        return response
 
     return web.Response(status=404)
+
+
+async def async_serve_static_file(request, servefile, requested_file):
+    """Serve a static file without an etag."""
+    if await async_path_exsist(servefile):
+        _LOGGER.debug("Serving %s from %s", requested_file, servefile)
+        response = web.FileResponse(servefile)
+        response.headers["Cache-Control"] = "public, max-age=2678400"
+        return response
+
+    _LOGGER.error(
+        "%s tried to request '%s' but the file does not exist",
+        request.remote,
+        servefile,
+    )
+    return None
+
+
+async def async_serve_static_file_with_etag(request, servefile, requested_file):
+    """Serve a static file with an etag."""
+    etag = await async_get_etag(servefile)
+    if_none_match_header = request.headers.get("if-none-match")
+
+    if (
+        etag is not None
+        and if_none_match_header is not None
+        and _match_etag(etag, if_none_match_header)
+    ):
+        _LOGGER.debug(
+            "Serving %s from %s with etag %s (not-modified)",
+            requested_file,
+            servefile,
+            etag,
+        )
+        return web.Response(status=304)
+
+    if etag is not None:
+        _LOGGER.debug(
+            "Serving %s from %s with etag %s (not cached)",
+            requested_file,
+            servefile,
+            etag,
+        )
+        response = web.FileResponse(servefile)
+        response.headers["Cache-Control"] = "must-revalidate, max-age=0"
+        response.headers["Etag"] = etag
+        return response
+
+    _LOGGER.error(
+        "%s tried to request '%s' but the file does not exist",
+        request.remote,
+        servefile,
+    )
+    return None
+
+
+def _match_etag(etag, if_none_match_header):
+    """Check to see if an etag matches."""
+    for if_none_match_ele in if_none_match_header.split(","):
+        if if_none_match_ele.strip() == etag:
+            return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ attrs==20.3.0
 backoff==1.10.0
 bellybutton==0.3.0
 colorlog==4.6.2
+fnvhash==0.1.0
 hacs_frontend==202011151903
 pre-commit==2.8.2
 PyGithub==1.53

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==20.3.0
 backoff==1.10.0
 bellybutton==0.3.0
 colorlog==4.6.2
-fnvhash==0.1.0
+fnvhash>=0.1.0<1.0.0
 hacs_frontend==202011221222
 pre-commit==2.8.2
 PyGithub==1.53


### PR DESCRIPTION
Since I couldn't come with a solution that avoided checking the files, we can at least prevent re-downloading them if they haven't changed which means refreshing the mobile app has to download ~160 bytes per file instead of the whole file which still makes a big difference.

Retains the `max-age=0` and forces revalidation.

Fixes #1653

```
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving simple-thermostat/simple-thermostat.js from /config/www/community/simple-thermostat/simple-thermostat.js with etag 0x6cda4805 (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving lovelace-fold-entity-row/fold-entity-row.js from /config/www/community/lovelace-fold-entity-row/fold-entity-row.js with etag 0xd548b9d3 (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving lovelace-card-tools/card-tools.js from /config/www/community/lovelace-card-tools/card-tools.js with etag 0x444c2ffc (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving lovelace-slider-entity-row/slider-entity-row.js from /config/www/community/lovelace-slider-entity-row/slider-entity-row.js with etag 0x1c2fe06c (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving garbage-collection-card/garbage-collection-card.js from /config/www/community/garbage-collection-card/garbage-collection-card.js with etag 0x3fd15b8d (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving mini-graph-card/mini-graph-card-bundle.js from /config/www/community/mini-graph-card/mini-graph-card-bundle.js with etag 0x9d487a51 (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving search-card/search-card.js from /config/www/community/search-card/search-card.js with etag 0xb87350ef (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving battery-state-card/battery-state-card.js from /config/www/community/battery-state-card/battery-state-card.js with etag 0xd0b41886 (not-modified)
2020-11-16 05:12:31 DEBUG (MainThread) [custom_components.hacs] Serving lovelace-card-templater/lovelace-card-templater.js from /config/www/community/lovelace-card-templater/lovelace-card-templater.js with etag 0xf30f0e11 (not-modified)
```