### PR TITLE
Remove Python 3.7 tests

### DIFF
--- a/.github/workflows/homeassistant.yml
+++ b/.github/workflows/homeassistant.yml
@@ -15,7 +15,7 @@ jobs:
       image: hacscontainer/${{ matrix.version }}
     strategy:
       matrix:
-        version: ["python37", "python38", "python39"]
+        version: ["python38", "python39"]
     runs-on: ubuntu-latest
     steps:
     - name: "Get the repository content"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
         PYTEST: true
     strategy:
       matrix:
-        version: ["python37", "python38", "python39"]
+        version: ["python38", "python39"]
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Home Assistant only works with python 3.8.0 or newer now. This removes Python 3.7 tests.