### PR TITLE
Use leading zeroes with displaying the ratelimit time

### DIFF
--- a/custom_components/hacs/operational/setup.py
+++ b/custom_components/hacs/operational/setup.py
@@ -157,7 +157,7 @@ async def async_hacs_startup():
     else:
         reset = datetime.fromtimestamp(int(hacs.github.client.ratelimits.reset))
         hacs.log.error(
-            "HACS is ratelimited, HACS will resume setup when the limit is cleared (%s:%s:%s)",
+            "HACS is ratelimited, HACS will resume setup when the limit is cleared (%02d:%02d:%02d)",
             reset.hour,
             reset.minute,
             reset.second,


### PR DESCRIPTION
Creates a more user friendly message when there is a rate limit. 

Behaviour before: 
```
homeassistant    | 2021-03-17 20:26:28 ERROR (MainThread) [custom_components.hacs] HACS is ratelimited, HACS will resume setup when the limit is cleared (21:6:18)
```

Behaviour after:
```
2021-03-17 20:28:38 ERROR (MainThread) [custom_components.hacs] HACS is ratelimited, HACS will resume setup when the limit is cleared (21:06:18)
```