### PR TITLE
Set minimum HA version to 2021.2.0

### DIFF
--- a/custom_components/hacs/const.py
+++ b/custom_components/hacs/const.py
@@ -6,7 +6,7 @@ NAME_SHORT = "HACS"
 INTEGRATION_VERSION = "main"
 DOMAIN = "hacs"
 CLIENT_ID = "395a8e669c5de9f7c6e8"
-MINIMUM_HA_VERSION = "2020.12.0"
+MINIMUM_HA_VERSION = "2021.2.0"
 PROJECT_URL = "https://github.com/hacs/integration/"
 CUSTOM_UPDATER_LOCATIONS = [
     "{}/custom_components/custom_updater.py",

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "HACS",
   "zip_release": true,
   "hide_default_branch": true,
-  "homeassistant": "2020.12.0",
+  "homeassistant": "2021.2.0",
   "hacs": "0.19.0",
   "filename": "hacs.zip"
 }


### PR DESCRIPTION
With https://github.com/hacs/integration/pull/1995 we now use python functionality that was added in Python 3.8.
Home Assistant 2021.2 has 3.8 as the minimum python version.