### PR TITLE
Fix Non-thread-safe operation invoked on an event loop other than the current one

### DIFF
--- a/custom_components/hacs/tasks/activate_categories.py
+++ b/custom_components/hacs/tasks/activate_categories.py
@@ -18,7 +18,7 @@ class Task(HacsTask):
 
     stages = [HacsStage.SETUP]
 
-    def execute(self) -> None:
+    async def async_execute(self) -> None:
         self.hacs.common.categories = set()
         for category in (HacsCategory.INTEGRATION, HacsCategory.PLUGIN):
             self.hacs.enable_hacs_category(HacsCategory(category))

--- a/custom_components/hacs/tasks/setup_frontend.py
+++ b/custom_components/hacs/tasks/setup_frontend.py
@@ -27,7 +27,7 @@ class Task(HacsTask):
 
     stages = [HacsStage.SETUP]
 
-    def execute(self) -> None:
+    async def async_execute(self) -> None:
 
         # Register themes
         self.hass.http.register_static_path(f"{URL_BASE}/themes", self.hass.config.path("themes"))


### PR DESCRIPTION
`2021-10-31 15:05:52 ERROR (MainThread) [custom_components.hacs] Task setup_frontend failed: Non-thread-safe operation invoked on an event loop other than the current one`