### PR TITLE
Read http proxy from env

### DIFF
--- a/custom_components/hacs/config_flow.py
+++ b/custom_components/hacs/config_flow.py
@@ -70,7 +70,7 @@ class HacsFlowHandler(HacsMixin, config_entries.ConfigFlow, domain=DOMAIN):
             if not self.device:
                 self.device = GitHubDeviceAPI(
                     client_id=CLIENT_ID,
-                    session=aiohttp_client.async_get_clientsession(self.hass),
+                    session=aiohttp_client.async_get_clientsession(self.hass, trust_env=True),
                     **{"client_name": f"HACS/{integration.version}"},
                 )
             async_call_later(self.hass, 1, _wait_for_activation)

--- a/custom_components/hacs/operational/setup.py
+++ b/custom_components/hacs/operational/setup.py
@@ -37,7 +37,7 @@ async def _async_common_setup(hass: HomeAssistant):
     hacs.hass = hass
     hacs.data = HacsData()
     hacs.system.running = True
-    hacs.session = async_create_clientsession(hass)
+    hacs.session = async_create_clientsession(hass, trust_env=True)
     hacs.tasks = HacsTaskManager(hacs=hacs, hass=hass)
 
     hacs.core.lovelace_mode = LovelaceMode.YAML
@@ -54,7 +54,7 @@ async def _async_common_setup(hass: HomeAssistant):
     await hacs.tasks.async_load()
 
     # Setup session for API clients
-    session = async_create_clientsession(hacs.hass)
+    session = async_create_clientsession(hacs.hass, trust_env=True)
 
     ## Legacy GitHub client
     hacs.github = GitHub(


### PR DESCRIPTION
GitHub has been blocked in some country like China. A common way is setup a proxy and set environment variable `HTTP_PROXY` & `HTTPS_PROXY`. However [aiohttp do not read environment variable by default](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support). It would be useful if hacs provide an option to specify http proxy.

