### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/custom_components/hacs/helpers/functions/download.py
+++ b/custom_components/hacs/helpers/functions/download.py
@@ -40,7 +40,7 @@ async def async_download_file(url):
 
     result = None
 
-    with async_timeout.timeout(60, loop=hacs.hass.loop):
+    with async_timeout.timeout(60):
         request = await hacs.session.get(url)
 
         # Make sure that we got a valid result


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed
