### PR TITLE
Fixed a typo in debug logging for queue_manager

### DIFF
--- a/custom_components/hacs/utils/queue_manager.py
+++ b/custom_components/hacs/utils/queue_manager.py
@@ -42,7 +42,7 @@ class QueueManager:
     async def execute(self, number_of_tasks: int | None = None) -> None:
         """Execute the tasks in the queue."""
         if self.running:
-            _LOGGER.debug("<QueueManager> Execution is allreay running")
+            _LOGGER.debug("<QueueManager> Execution is already running")
             raise HacsExecutionStillInProgress
         if len(self.queue) == 0:
             _LOGGER.debug("<QueueManager> The queue is empty")


### PR DESCRIPTION
Just before my upgrade to 1.24.5, I wanted to do a diff with my currently installed version to see if any unexpected changes were submitted (e.g. preparations for April fools 😉 ). During this diff I noticed a typo and ought to make a PR.

Please let me know if you require any thing else from my side to get this typo fixed.