### PR TITLE
Limit API usage for scheduled refresh

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -633,7 +633,7 @@ class HacsBase:
         )
         self.recuring_tasks.append(
             self.hass.helpers.event.async_track_time_interval(
-                self.async_update_all_repositories, timedelta(hours=25)
+                self.async_update_all_repositories, timedelta(hours=96)
             )
         )
         self.recuring_tasks.append(
@@ -648,7 +648,7 @@ class HacsBase:
         )
         self.recuring_tasks.append(
             self.hass.helpers.event.async_track_time_interval(
-                self.async_update_downloaded_repositories, timedelta(hours=2)
+                self.async_update_downloaded_repositories, timedelta(hours=48)
             )
         )
         self.recuring_tasks.append(


### PR DESCRIPTION
Currently, it's checked on-demand, startup, and every 2h/25h.
That's a bit excessive, the on-demand and startup checks are unchanged, but the schedules are changed to 48h/96h.

Related to #2977 