### PR TITLE
Drop refresh from API during startup

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -980,7 +980,7 @@ class HacsBase:
 
     async def async_update_downloaded_repositories(self, _=None) -> None:
         """Execute the task."""
-        if self.system.disabled:
+        if self.system.disabled or self.configuration.experimental:
             return
         self.log.info("Starting recurring background task for downloaded repositories")
 


### PR DESCRIPTION
During the startup of HACS the GitHub API would be used to refresh the data of all downloaded repositories, this is no longer needed.