### PR TITLE
Use async_forward_entry_setups instead of async_setup_platforms

### DIFF
--- a/custom_components/hacs/__init__.py
+++ b/custom_components/hacs/__init__.py
@@ -174,7 +174,7 @@ async def async_initialize_integration(
             hacs.log.info("Update entities are only supported when using UI configuration")
 
         else:
-            hass.config_entries.async_setup_platforms(
+            await hass.config_entries.async_forward_entry_setups(
                 config_entry,
                 [Platform.SENSOR, Platform.UPDATE]
                 if hacs.configuration.experimental


### PR DESCRIPTION
- Replaces current async_setup_platforms function with async_forward_entry_setups, which will prevent the integration failing to start in Home Assistant 2023.3+

Fixes #3037 