### PR TITLE
Bump min HA version to 2023.6.0 and python to 3.11

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "hacs/integration",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye",
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
   "postCreateCommand": "scripts/setup",
   "forwardPorts": [
     8123

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@v3.5.3
@@ -51,7 +51,7 @@ jobs:
           curl -sfSL https://codecov.io/bash | bash -
 
   legacy:
-    name: With pytest with Home Assistant 2022.11.0
+    name: With pytest with Home Assistant 2023.6.0
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout the repository

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,7 +88,7 @@ jobs:
     name: With Home Assistant
     strategy:
       matrix:
-        channel: [stable, beta, dev, "2022.11.0"]
+        channel: [stable, beta, dev, "2023.6.0"]
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout the repository

--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ludeeus/alpine/python:3.10
+FROM ghcr.io/ludeeus/alpine/python:3.11
 
 WORKDIR /hacs
 

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "HACS",
   "zip_release": true,
   "hide_default_branch": true,
-  "homeassistant": "2022.11.0",
+  "homeassistant": "2023.6.0",
   "hacs": "0.19.0",
   "filename": "hacs.zip"
 }


### PR DESCRIPTION
HACS now requires Home Assistant 2023.6.0 or newer, which again requires python 3.11+