### PR TITLE
Remove un-needed version check

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -770,7 +770,7 @@ class HacsBase:
         for category in (HacsCategory.INTEGRATION, HacsCategory.PLUGIN):
             self.enable_hacs_category(HacsCategory(category))
 
-        if self.configuration.experimental and self.core.ha_version >= "2023.4.0b0":
+        if self.configuration.experimental:
             self.enable_hacs_category(HacsCategory.TEMPLATE)
 
         if (


### PR DESCRIPTION
HACS requires > 2023.6, so this check is no longer needed.