### PR TITLE
Prevent creating new `_login_device` when already exists

### DIFF
--- a/custom_components/hacs/config_flow.py
+++ b/custom_components/hacs/config_flow.py
@@ -94,6 +94,15 @@ class HacsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     session=aiohttp_client.async_get_clientsession(self.hass),
                     **{"client_name": f"HACS/{integration.version}"},
                 )
+            if self._login_device:
+                return self.async_show_progress(
+                    step_id="device",
+                    progress_action="wait_for_device",
+                    description_placeholders={
+                        "url": OAUTH_USER_LOGIN,
+                        "code": self._login_device.user_code,
+                    },
+                )
             async_call_later(self.hass, 1, _wait_for_activation)
             try:
                 response = await self.device.register()


### PR DESCRIPTION
The flow didn't keep its state properly, if a `_login_device` was already created, and the flow was refetched, a new `_login_device` would be created, this would cause an `data_entry_flow_progressed` event that would fetch the flow again causing a loop.

Fixes https://github.com/hacs/integration/issues/3384