### PR TITLE
Workaround for async_step_device_done called twice while configuring

### DIFF
--- a/custom_components/hacs/config_flow.py
+++ b/custom_components/hacs/config_flow.py
@@ -170,6 +170,10 @@ class HacsFlowHandler(ConfigFlow, domain=DOMAIN):
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
+        if self._async_current_entries():
+            # Dirty workaround with bad UX...
+            return self.async_abort(reason="single_instance_allowed")
+
         return self.async_create_entry(
             title="",
             data={


### PR DESCRIPTION
Currently on dev and later with 2024.2.0b0, this will start to be called twice, which will result in 2 config entries being created.