### PR TITLE
Use Python 3.12 for testing against core dev

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -85,10 +85,10 @@ jobs:
       - name: 📥 Checkout the repository
         uses: actions/checkout@v4.1.1
 
-      - name: 🛠️ Set up Python 3.11
+      - name: 🛠️ Set up Python 3.12
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt

--- a/tests/common.py
+++ b/tests/common.py
@@ -148,6 +148,8 @@ async def async_test_home_assistant(loop, tmpdir):
     hass.data = {
         "integrations": {},
         "custom_components": {},
+        "preload_platforms": [],
+        "missing_platforms": [],
         "components": {},
         "device_registry": DeviceRegistry(hass),
         "entity_registry": EntityRegistry(hass),


### PR DESCRIPTION
Currently, the tests against core dev are failing due to core requiring Python 3.12