### PR TITLE
Handle unloaded config entry in system_health_info

### DIFF
--- a/custom_components/hacs/system_health.py
+++ b/custom_components/hacs/system_health.py
@@ -1,4 +1,6 @@
 """Provide info to system health."""
+from typing import Any
+
 from aiogithubapi.common.const import BASE_API_URL
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
@@ -17,8 +19,11 @@ def async_register(hass: HomeAssistant, register: system_health.SystemHealthRegi
     register.async_register_info(system_health_info, "/hacs")
 
 
-async def system_health_info(hass):
+async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the info page."""
+    if DOMAIN not in hass.data:
+        return {"Disabled": "HACS is not loaded, but HA still requests this information..."}
+
     hacs: HacsBase = hass.data[DOMAIN]
     response = await hacs.githubapi.rate_limit()
 

--- a/tests/snapshots/system_health/system_health_after_unload.json
+++ b/tests/snapshots/system_health/system_health_after_unload.json
@@ -1,0 +1,3 @@
+{
+    "Disabled": "HACS is not loaded, but HA still requests this information..."
+}

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -72,8 +72,9 @@ async def test_system_health_after_unload(
     assert await async_setup_component(hass, "system_health", {})
     await hass.async_block_till_done()
 
-    with pytest.raises(KeyError, match="hacs"):
-        await get_system_health_info(hass, HACS_SYSTEM_HEALTH_DOMAIN)
+    info = await get_system_health_info(hass, HACS_SYSTEM_HEALTH_DOMAIN)
+
+    assert info == {"Disabled": "HACS is not loaded, but HA still requests this information..."}
 
 
 async def test_system_health_no_hacs(

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -65,6 +65,7 @@ async def test_system_health(
 async def test_system_health_after_unload(
     hacs: HacsBase,
     hass: HomeAssistant,
+    snapshots: SnapshotFixture,
 ) -> None:
     """Test HACS system health."""
     await hass.config_entries.async_unload(hacs.configuration.config_entry.entry_id)
@@ -74,7 +75,7 @@ async def test_system_health_after_unload(
 
     info = await get_system_health_info(hass, HACS_SYSTEM_HEALTH_DOMAIN)
 
-    assert info == {"Disabled": "HACS is not loaded, but HA still requests this information..."}
+    snapshots.assert_match(safe_json_dumps(info), "system_health/system_health_after_unload.json")
 
 
 async def test_system_health_no_hacs(


### PR DESCRIPTION
## Background

There's no way for an integration to remove a registered system health platform, so we need to handle the case where the HACS config entry is removed or disabled after core startup, and the user then get system health info.

~~Tests in https://github.com/hacs/integration/pull/3604 will need to be updated~~