### PR TITLE
Adjust pytest configuration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,8 +43,7 @@ jobs:
       - name: 🏃 Run tests
         env:
           PYTEST: true
-        run: |
-          python3 -m pytest
+        run: scripts/test
 
   dev:
     name: With pytest with Home Assistant (${{ matrix.homeassistant-version }}) & Python (${{ matrix.python-version }})
@@ -82,8 +81,7 @@ jobs:
       - name: 🏃 Run tests
         env:
           PYTEST: true
-        run: |
-          python3 -m pytest
+        run: scripts/test
 
       - name: 📤 Upload coverage to Codecov
         if: ${{ matrix.python-version == '3.12' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,12 @@ combine_as_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode="auto"
-addopts = "-rf -v -l --cov=./ --cov-report=xml"
+addopts = "-rxf -l --cov=./ --cov-report=xml"
 filterwarnings = [
     "ignore::DeprecationWarning",
 ]
+log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
 testpaths = [
     "tests",
 ]

--- a/scripts/test
+++ b/scripts/test
@@ -4,10 +4,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-python3 -m \
-    pytest \
-    tests \
-    -rxf -x -v -l \
-    --cov=./ \
-    --cov-report=xml
+python3 -m pytest -x tests
 


### PR DESCRIPTION
Currently, GitHub has a hard time loading the logs if there are multiple failures.
This changes the test action to quit early-