### PR TITLE
Run black on the action as well

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args:
           - --safe
           - --quiet
-        files: ^((custom_components|script|tests)/.+)?[^/]+\.py$
+        files: ^((action|custom_components|script|tests)/.+)?[^/]+\.py$
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/action/action.py
+++ b/action/action.py
@@ -171,5 +171,6 @@ async def validate_repository(hacs, repository, category, ref=None):
     except HacsException as exception:
         error(exception)
 
+
 if __name__ == "__main__":
     asyncio.run(preflight())


### PR DESCRIPTION
While setting up a development env, I noticed a formatting change on a Python file in the actions folder (as I ran black manually).

Might just as well add the `action` to the formatting.