### PR TITLE
Add isort to CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,7 @@ jobs:
           - requirements-txt-fixer
           - check-ast
           - mixed-line-ending
+          - isort
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@v4.1.1

--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from asyncio import sleep
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 import os
 import pathlib
 import shutil

--- a/custom_components/hacs/utils/data.py
+++ b/custom_components/hacs/utils/data.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.core import callback

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -12,7 +12,6 @@ from custom_components.hacs.base import HacsBase
 from tests.common import MockedResponse, ResponseMocker, safe_json_dumps
 from tests.conftest import SnapshotFixture
 
-
 HACS_SYSTEM_HEALTH_DOMAIN = "Home Assistant Community Store"
 
 


### PR DESCRIPTION
I noticed that isort wasn't ran in CI, yet it is part of pre-commit (and thus the local lint script).

Running it, caused changes, which are in this PR.