### PR TITLE
Show diff when API calls have changed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import shutil
 from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
+from _pytest.assertion.util import _compare_eq_iterable
 from awesomeversion import AwesomeVersion
 import freezegun
 from homeassistant import loader
@@ -418,4 +419,20 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     with open("tests/output/proxy_calls.json", encoding="utf-8") as file:
         current = json.load(file)
         if current != filtered_calls:
-            raise AssertionError("API calls have changed, run scripts/snapshot-update")
+            diff = ""
+            for test in current:
+                if test not in filtered_calls:
+                    diff += f"Test '{test}' was removed\n"
+            for test in filtered_calls:
+                if test not in current:
+                    diff += f"Test '{test}' was added\n"
+            for test in filtered_calls:
+                if test not in current:
+                    continue
+                if filtered_calls[test] == current[test]:
+                    continue
+                diff += f"Test '{test}' has changed\n"
+                diff += '\n'.join(_compare_eq_iterable(filtered_calls[test], current[test], 3))
+                diff += '\n'
+
+            raise AssertionError(f"API calls have changed, run scripts/snapshot-update\n{diff}")


### PR DESCRIPTION
Show diff when API calls have changed

Example output:
```
AssertionError: API calls have changed, run scripts/snapshot-update
Test 'tests/action/test_hacs_action_integration.py::test_hacs_action_integration[bad_documentation-manifest0-False]' has changed
Full diff:
  {
-  'https://api.github.com/repos/hacs-test-org/integration-basic': 1,
?                                                                  ^
+  'https://api.github.com/repos/hacs-test-org/integration-basic': 2,
?                                                                  ^
   'https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json': 2,
   'https://api.github.com/repos/hacs-test-org/integration-basic/contents/hacs.json': 2,
   'https://api.github.com/repos/hacs-test-org/integration-basic/git/trees/main': 1,
   'https://api.github.com/repos/hacs-test-org/integration-basic/releases': 1,
   'https://brands.home-assistant.io/domains.json': 1,
  }
Test 'tests/hacsbase/test_backup.py::test_directory' has changed
Full diff:
  {
   'https://api.github.com/repos/hacs/integration': 1,
   'https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json': 1,
   'https://api.github.com/repos/hacs/integration/contents/hacs.json': 1,
   'https://api.github.com/repos/hacs/integration/git/trees/main': 1,
-  'https://api.github.com/repos/hacs/integration/releases': 2,
?                                                            ^
+  'https://api.github.com/repos/hacs/integration/releases': 1,
?                                                            ^
  }
```