### PR TITLE
Bump Python version used in CI

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-python@v5.1.0
         id: python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v5.1.0
         id: python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 🛠️ Set up Python
         uses: actions/setup-python@v5.1.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: 🔢 Get version
         if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.1.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt


### PR DESCRIPTION
Bump Python version used in CI

This bumps the Python version used in CI, except for the version used when running integration tests, to 3.12