### PR TITLE
Fix races in config flow tests

### DIFF
--- a/tests/output/proxy_calls.json
+++ b/tests/output/proxy_calls.json
@@ -970,17 +970,18 @@
     },
     "tests/test_config_flow.py::test_flow_with_activation_failure": {
         "https://github.com/login/device/code": 1,
-        "https://github.com/login/oauth/access_token": 1
+        "https://github.com/login/oauth/access_token": 2
     },
     "tests/test_config_flow.py::test_flow_with_registration_failure": {
         "https://github.com/login/device/code": 1
     },
     "tests/test_config_flow.py::test_flow_with_remove_while_activating": {
-        "https://github.com/login/device/code": 1
+        "https://github.com/login/device/code": 1,
+        "https://github.com/login/oauth/access_token": 1
     },
     "tests/test_config_flow.py::test_full_user_flow_implementation": {
         "https://github.com/login/device/code": 1,
-        "https://github.com/login/oauth/access_token": 1
+        "https://github.com/login/oauth/access_token": 2
     },
     "tests/test_config_flow.py::test_options_flow": {
         "https://api.github.com/repos/hacs/integration": 1,


### PR DESCRIPTION
Fix races in config flow tests where the tests did not ensure the configured requests mock were accessed as expected