### PR TITLE
Increase time between running async_process_queue and async_handle_critical_repositories

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -679,7 +679,7 @@ class HacsBase:
 
         self.recurring_tasks.append(
             async_track_time_interval(
-                self.hass, self.async_handle_critical_repositories, timedelta(hours=6)
+                self.hass, self.async_handle_critical_repositories, timedelta(hours=24)
             )
         )
 

--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -674,7 +674,7 @@ class HacsBase:
             async_track_time_interval(self.hass, self.async_check_rate_limit, timedelta(minutes=5))
         )
         self.recurring_tasks.append(
-            async_track_time_interval(self.hass, self.async_process_queue, timedelta(minutes=10))
+            async_track_time_interval(self.hass, self.async_process_queue, timedelta(minutes=30))
         )
 
         self.recurring_tasks.append(


### PR DESCRIPTION
👋 from GitHub! Big fan of this project!

As is, the integration makes a lot of GitHub API calls to get repository information. This project is a statistically significant consumer of our API resources, and we'd like to see if we can lighten the load a bit while still maintaining the integration's functionality. 

This PR proposes polling less frequently. I **think** I found the right config that controls the polling but would be very happy to learn if there are better / other spots to update. Are there impacts of making this change that I am not aware of? Thank you!