### PR TITLE
Show more errors in the generator logs

### DIFF
--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -1074,7 +1074,7 @@ class HacsRepository:
         except HacsRepositoryExistException:
             raise HacsRepositoryExistException from None
         except (AIOGitHubAPIException, HacsException) as exception:
-            if not self.hacs.status.startup:
+            if not self.hacs.status.startup or self.hacs.system.generator:
                 self.logger.error("%s %s", self.string, exception)
             if not ignore_issues:
                 self.validate.errors.append("Repository does not exist.")


### PR DESCRIPTION
Currently, when a repository is removed (and GitHub returns 404), that is never shown in the generator logs. 
