### PR TITLE
fix: github action will miss ref and use default branch 

### DIFF
--- a/action/action.py
+++ b/action/action.py
@@ -155,7 +155,7 @@ async def preflight():
 async def validate_repository(hacs, repository, category, ref=None):
     """Validate."""
 
-    ## Legacy GitHub client
+    # Legacy GitHub client
     hacs.github = GitHub(
         hacs.configuration.token,
         hacs.session,

--- a/custom_components/hacs/__init__.py
+++ b/custom_components/hacs/__init__.py
@@ -87,7 +87,7 @@ async def _async_initialize_integration(
     if hacs.core.ha_version is None:
         hacs.core.ha_version = AwesomeVersion(HAVERSION)
 
-    ## Legacy GitHub client
+    # Legacy GitHub client
     hacs.github = GitHub(
         hacs.configuration.token,
         clientsession,
@@ -97,7 +97,7 @@ async def _async_initialize_integration(
         },
     )
 
-    ## New GitHub client
+    # New GitHub client
     hacs.githubapi = GitHubAPI(
         token=hacs.configuration.token,
         session=clientsession,

--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -61,7 +61,6 @@ from .exceptions import (
 from .repositories import REPOSITORY_CLASSES
 from .repositories.base import HACS_MANIFEST_KEYS_TO_EXPORT, REPOSITORY_KEYS_TO_EXPORT
 from .utils.file_system import async_exists
-from .utils.json import json_loads
 from .utils.logger import LOGGER
 from .utils.queue_manager import QueueManager
 from .utils.store import async_load_from_store, async_save_to_store

--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -476,7 +476,7 @@ class HacsRepository:
 
         # Get the content of hacs.json
         if RepositoryFile.HACS_JSON in [x.filename for x in self.tree]:
-            if manifest := await self.async_get_hacs_json():
+            if manifest := await self.async_get_hacs_json(ref=self.ref):
                 self.repository_manifest = HacsManifest.from_dict(manifest)
                 self.data.update_data(
                     self.repository_manifest.to_dict(),
@@ -539,7 +539,7 @@ class HacsRepository:
 
         # Get the content of hacs.json
         if RepositoryFile.HACS_JSON in [x.filename for x in self.tree]:
-            if manifest := await self.async_get_hacs_json():
+            if manifest := await self.async_get_hacs_json(ref=self.ref):
                 self.repository_manifest = HacsManifest.from_dict(manifest)
                 self.data.update_data(
                     self.repository_manifest.to_dict(),

--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -86,12 +86,12 @@ class HacsIntegrationRepository(HacsRepository):
                 ):
                     raise AddonRepositoryException()
                 raise HacsException(
-                    f"{self.string} Repository structure for {self.ref.replace('tags/','')} is not compliant"
+                    f"{self.string} Repository structure for {self.ref.replace('tags/', '')} is not compliant"
                 )
             self.content.path.remote = f"custom_components/{name}"
 
         # Get the content of manifest.json
-        if manifest := await self.async_get_integration_manifest():
+        if manifest := await self.async_get_integration_manifest(ref=self.ref):
             try:
                 self.integration_manifest = manifest
                 self.data.authors = manifest.get("codeowners", [])
@@ -101,7 +101,7 @@ class HacsIntegrationRepository(HacsRepository):
 
             except KeyError as exception:
                 self.validate.errors.append(
-                    f"Missing expected key '{exception}' in { RepositoryFile.MAINIFEST_JSON}"
+                    f"Missing expected key '{exception}' in {RepositoryFile.MAINIFEST_JSON}"
                 )
                 self.hacs.log.error(
                     "Missing expected key '%s' in '%s'", exception, RepositoryFile.MAINIFEST_JSON
@@ -131,7 +131,7 @@ class HacsIntegrationRepository(HacsRepository):
             self.content.path.remote = f"custom_components/{name}"
 
         # Get the content of manifest.json
-        if manifest := await self.async_get_integration_manifest():
+        if manifest := await self.async_get_integration_manifest(ref=self.ref):
             try:
                 self.integration_manifest = manifest
                 self.data.authors = manifest.get("codeowners", [])
@@ -141,7 +141,7 @@ class HacsIntegrationRepository(HacsRepository):
 
             except KeyError as exception:
                 self.validate.errors.append(
-                    f"Missing expected key '{exception}' in { RepositoryFile.MAINIFEST_JSON}"
+                    f"Missing expected key '{exception}' in {RepositoryFile.MAINIFEST_JSON}"
                 )
                 self.hacs.log.error(
                     "Missing expected key '%s' in '%s'", exception, RepositoryFile.MAINIFEST_JSON
@@ -177,7 +177,7 @@ class HacsIntegrationRepository(HacsRepository):
             else f"{self.content.path.remote}/{RepositoryFile.MAINIFEST_JSON}"
         )
 
-        if not manifest_path in (x.full_path for x in self.tree):
+        if manifest_path not in (x.full_path for x in self.tree):
             raise HacsException(f"No {RepositoryFile.MAINIFEST_JSON} file found '{manifest_path}'")
 
         response = await self.hacs.async_github_api_method(


### PR DESCRIPTION
Issue:

we want to migrate a domain name,  PR： https://github.com/wuwentao/midea_ac_lan/pull/159
PR submit from fork repo with different branch name.

github action uses `hacs/action@main ` to verify PR
it only return “Error: Not Found”
no any ERROR log or step output in debug mode.

after fork it and add too many log info to print the step and args, found it caused by `ref` args miss:

1. `action.py`  run  `hacs.async_register_repository()` with `ref` args
2. `async_register_repository` defined in `custom_components/hacs/base.py`  line 562, it call `await repository.async_registration(ref)`, also include `ref` args
3.  and `repository.async_registration(ref)` defined in `custom_components/hacs/repositories/base.py`,  in line 842, it call `self.validate_repository()` without `ref `args, but `self.ref` is available
4. `validate_repository()` defined in `custom_components/hacs/repositories/integration.py`, in line 73, it call `common_validate` in `custom_components/hacs/repositories/base.py`, and it will run this line `if manifest := await self.async_get_hacs_json():`, it missed `ref` args, so add arg: `ref=self.ref` to fix it.
5. but it will not return error during domain rename, as it using default branch hacs.json. it check pass, continue the remaining jobs, in `custom_components/hacs/repositories/integration.py` after line 73 in `validate_repository()`.
6. error found in line 94: `if manifest := await self.async_get_integration_manifest():` , also missed ref args and use default branch value.
7. in `async_get_integration_manifest`, as there is domain rename and dir rename, default branch don't have this dir and `mainfest.json`, it continue using default branch and call `response = await self.hacs.async_github_api_method()` in line 183
8. `async_github_api_method()` definded in `custom_components/hacs/base.py` line 492, and `try` job can't pass with a exception: `Not Found`, so only print this error log.


checked with the same `async_get_integration_manifest` and `async_get_hacs_json`, add `ref=self.ref` to run it in normal branch and action.

issue fixed.


in addtion, also remove some minior error , like duplicate `##` comments, remove `from .utils.json import json_loads` as import but not used.

please help to review and confirm whether it's the expect result.


github action error log: 
https://github.com/wuwentao/midea_ac_lan/actions/runs/9672246348/job/26686312538

after add the `ref` args fix, it can report the expect ERROR log as below:
https://github.com/wuwentao/midea_ac_lan/actions/runs/9672246348/job/26687155544

Thanks


