### PR TITLE
Fix update entity missing after installing HACS

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -788,7 +788,9 @@ class HacsBase:
 
         try:
             repository = self.repositories.get_by_full_name(HacsGitHubRepo.INTEGRATION)
+            should_recreate_entities = False
             if repository is None:
+                should_recreate_entities = True
                 await self.async_register_repository(
                     repository_full_name=HacsGitHubRepo.INTEGRATION,
                     category=HacsCategory.INTEGRATION,
@@ -805,6 +807,9 @@ class HacsBase:
             repository.data.installed_version = self.integration.version.string
             repository.data.new = False
             repository.data.releases = True
+
+            if should_recreate_entities:
+                await self.async_recreate_entities()
 
             self.repository = repository.repository_object
             self.repositories.mark_default(repository)

--- a/tests/snapshots/hacs-test-org/appdaemon-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/appdaemon-basic/test_discard_invalid_repo_data.json
@@ -56,7 +56,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/appdaemon-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/appdaemon-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/appdaemon-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/appdaemon-basic/test_remove_repository_pre.json
@@ -73,7 +73,37 @@
         "/config/appdaemon/apps/appdaemon-basic/__init__.py",
         "/config/appdaemon/apps/appdaemon-basic/example.py"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/appdaemon-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/appdaemon-basic/test_update_repository_websocket.json
@@ -89,7 +89,37 @@
     "_directory": [
         "/config/appdaemon/apps/appdaemon-basic/__init__.py"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/integration-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/integration-basic/test_discard_invalid_repo_data.json
@@ -52,7 +52,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/integration-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/integration-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/integration-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/integration-basic/test_remove_repository_pre.json
@@ -76,7 +76,37 @@
         "/config/custom_components/example/manifest.json",
         "/config/custom_components/example/module/__init__.py"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/integration-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/integration-basic/test_update_repository_websocket.json
@@ -93,7 +93,37 @@
         "/config/custom_components/example/__init__.py",
         "/config/custom_components/example/manifest.json"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/plugin-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/plugin-basic/test_discard_invalid_repo_data.json
@@ -50,7 +50,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/plugin-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/plugin-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/plugin-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/plugin-basic/test_remove_repository_pre.json
@@ -78,7 +78,37 @@
         "/config/www/community/plugin-basic/example.js",
         "/config/www/community/plugin-basic/example.js.gz"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/plugin-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/plugin-basic/test_update_repository_websocket.json
@@ -95,7 +95,37 @@
         "/config/www/community/plugin-basic/plugin-basic.js",
         "/config/www/community/plugin-basic/plugin-basic.js.gz"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/python_script-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/python_script-basic/test_discard_invalid_repo_data.json
@@ -50,7 +50,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/python_script-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/python_script-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/python_script-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/python_script-basic/test_remove_repository_pre.json
@@ -72,7 +72,37 @@
     "_directory": [
         "/config/python_scripts/example.py"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/python_script-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/python_script-basic/test_update_repository_websocket.json
@@ -89,7 +89,37 @@
     "_directory": [
         "/config/python_scripts/example.py"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/template-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/template-basic/test_discard_invalid_repo_data.json
@@ -50,7 +50,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/template-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/template-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/template-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/template-basic/test_remove_repository_pre.json
@@ -72,7 +72,37 @@
     "_directory": [
         "/config/custom_templates/example.jinja"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/template-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/template-basic/test_update_repository_websocket.json
@@ -90,7 +90,37 @@
     "_directory": [
         "/config/custom_templates/example.jinja"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/theme-basic/test_discard_invalid_repo_data.json
+++ b/tests/snapshots/hacs-test-org/theme-basic/test_discard_invalid_repo_data.json
@@ -50,7 +50,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/theme-basic/test_remove_repository_post.json
+++ b/tests/snapshots/hacs-test-org/theme-basic/test_remove_repository_post.json
@@ -62,7 +62,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/theme-basic/test_remove_repository_pre.json
+++ b/tests/snapshots/hacs-test-org/theme-basic/test_remove_repository_pre.json
@@ -72,7 +72,37 @@
     "_directory": [
         "/config/themes/example/example.yaml"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/hacs-test-org/theme-basic/test_update_repository_websocket.json
+++ b/tests/snapshots/hacs-test-org/theme-basic/test_update_repository_websocket.json
@@ -90,7 +90,37 @@
     "_directory": [
         "/config/themes/example/example.yaml"
     ],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,

--- a/tests/snapshots/test_integration_setup.json
+++ b/tests/snapshots/test_integration_setup.json
@@ -56,7 +56,37 @@
         }
     },
     "_directory": [],
-    "_entities": [],
+    "_entities": [
+        {
+            "area_id": null,
+            "attributes": {
+                "auto_update": false,
+                "entity_picture": "https://brands.home-assistant.io/_/hacs/icon.png",
+                "friendly_name": "HACS update",
+                "in_progress": false,
+                "installed_version": "0.0.0",
+                "latest_version": "",
+                "release_summary": null,
+                "release_url": "https://github.com/hacs/integration/releases/",
+                "skipped_version": null,
+                "supported_features": 23,
+                "title": null
+            },
+            "disabled_by": null,
+            "entity_category": "config",
+            "entity_id": "update.hacs_update",
+            "has_entity_name": false,
+            "hidden_by": null,
+            "icon": null,
+            "name": null,
+            "options": {},
+            "original_name": "HACS update",
+            "platform": "hacs",
+            "state": "on",
+            "translation_key": null,
+            "unique_id": "172733314"
+        }
+    ],
     "_hacs": {
         "configuration": {
             "debug": false,


### PR DESCRIPTION
Fix update entity missing after installing HACS

This fixes a bug where no update entity was created for the HACS repository until after a core restart or after configuring another repoository.

Needs https://github.com/hacs/integration/pull/3844 for tests to pass