### PR TITLE
Use GraphQL to generate release content

### DIFF
--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -114,6 +114,7 @@ REPOSITORY_KEYS_TO_EXPORT = (
     ("last_version", None),
     ("manifest_name", None),
     ("open_issues", 0),
+    ("prerelease", None),
     ("stargazers_count", 0),
     ("topics", []),
 )
@@ -165,6 +166,7 @@ class RepositoryData:
     manifest_name: str = None
     new: bool = True
     open_issues: int = 0
+    prerelease: str = None
     published_tags: list[str] = []
     releases: bool = False
     selected_tag: str = None
@@ -569,9 +571,11 @@ class HacsRepository:
                 ),
                 validate,
             )
-        except BaseException:  # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        except BaseException:
             validate.errors.append(
-                f"Download of {self.repository_manifest.filename} was not completed"
+                f"Download of {
+                    self.repository_manifest.filename} was not completed"
             )
 
     async def async_download_zip_file(
@@ -610,7 +614,8 @@ class HacsRepository:
                 return
 
             validate.errors.append(f"[{content['name']}] was not downloaded")
-        except BaseException:  # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        except BaseException:
             validate.errors.append("Download was not completed")
 
     async def download_content(self, version: string | None = None) -> None:
@@ -719,7 +724,8 @@ class HacsRepository:
             )
             if response:
                 return json_loads(decode_content(response.data.content))
-        except BaseException:  # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        # lgtm [py/catch-base-exception] pylint: disable=broad-except
+        except BaseException:
             pass
 
     async def async_get_info_file_contents(self, *, version: str | None = None, **kwargs) -> str:
@@ -820,7 +826,8 @@ class HacsRepository:
                 )
 
         except (
-            BaseException  # lgtm [py/catch-base-exception] pylint: disable=broad-except
+            # lgtm [py/catch-base-exception] pylint: disable=broad-except
+            BaseException
         ) as exception:
             self.logger.debug("%s Removing %s failed with %s", self.string, local_path, exception)
             return False
@@ -945,7 +952,8 @@ class HacsRepository:
             ):
                 persistent_directory = Backup(
                     hacs=self.hacs,
-                    local_path=f"{self.content.path.local}/{self.repository_manifest.persistent_directory}",
+                    local_path=f"{
+                        self.content.path.local}/{self.repository_manifest.persistent_directory}",
                     backup_path=tempfile.gettempdir() + "/hacs_persistent_directory/",
                 )
                 await self.hacs.hass.async_add_executor_job(persistent_directory.create)
@@ -1272,7 +1280,8 @@ class HacsRepository:
             self.validate.errors.append(f"[{content.name}] was not downloaded.")
 
         except (
-            BaseException  # lgtm [py/catch-base-exception] pylint: disable=broad-except
+            # lgtm [py/catch-base-exception] pylint: disable=broad-except
+            BaseException
         ) as exception:
             self.validate.errors.append(f"Download was not completed [{exception}]")
 
@@ -1332,7 +1341,8 @@ class HacsRepository:
             return None
 
         result = await self.hacs.async_download_file(
-            f"https://raw.githubusercontent.com/{self.data.full_name}/{target_version}/{filename}",
+            f"https://raw.githubusercontent.com/{
+                self.data.full_name}/{target_version}/{filename}",
             nolog=True,
         )
 
@@ -1349,7 +1359,8 @@ class HacsRepository:
         self.logger.debug("%s Getting hacs.json for version=%s", self.string, version)
         try:
             result = await self.hacs.async_download_file(
-                f"https://raw.githubusercontent.com/{self.data.full_name}/{version}/hacs.json",
+                f"https://raw.githubusercontent.com/{
+                    self.data.full_name}/{version}/hacs.json",
                 nolog=True,
             )
             if result is None:

--- a/custom_components/hacs/utils/data.py
+++ b/custom_components/hacs/utils/data.py
@@ -47,6 +47,7 @@ EXPORTED_DOWNLOADED_REPOSITORY_DATA = EXPORTED_REPOSITORY_DATA + (
     ("last_version", None),
     ("manifest_name", None),
     ("open_issues", 0),
+    ("prerelease", None),
     ("published_tags", []),
     ("releases", False),
     ("selected_tag", None),
@@ -289,6 +290,7 @@ class HacsData:
         repository.data.selected_tag = repository_data.get("selected_tag")
         repository.data.show_beta = repository_data.get("show_beta", False)
         repository.data.last_version = repository_data.get("last_version")
+        repository.data.prerelease = repository_data.get("prerelease")
         repository.data.last_commit = repository_data.get("last_commit")
         repository.data.installed_version = repository_data.get("version_installed")
         repository.data.installed_commit = repository_data.get("installed_commit")
@@ -300,6 +302,9 @@ class HacsData:
         repository.repository_manifest = HacsManifest.from_dict(
             repository_data.get("manifest") or repository_data.get("repository_manifest") or {}
         )
+
+        if repository.data.prerelease == repository.data.last_version:
+            repository.data.prerelease = None
 
         if repository.localpath is not None and is_safe(self.hacs, repository.localpath):
             # Set local path

--- a/custom_components/hacs/utils/validate.py
+++ b/custom_components/hacs/utils/validate.py
@@ -118,6 +118,7 @@ V2_COMMON_DATA_JSON_SCHEMA = {
     vol.Required("last_fetched"): vol.Any(int, float),
     vol.Required("last_updated"): str,
     vol.Optional("last_version"): str,
+    vol.Optional("prerelease"): str,
     vol.Required("manifest"): {
         vol.Optional("country"): vol.Any([str], False),
         vol.Optional("name"): str,

--- a/tests/output/proxy_calls.json
+++ b/tests/output/proxy_calls.json
@@ -1252,6 +1252,23 @@
         "https://api.github.com/repos/hacs-test-org/theme-basic/releases": 1,
         "https://data-v2.hacs.xyz/theme/data.json": 1
     },
+    "tests/scripts/data/test_generate_category_data.py::test_generate_category_data_with_prior_content[category_test_data0]": {
+        "https://api.github.com/graphql": 1,
+        "https://api.github.com/rate_limit": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic-custom": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic-custom/contents/custom_components/example/manifest.json": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic-custom/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic-custom/git/trees/1.0.0": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic-custom/releases": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic/git/trees/1.0.0": 1,
+        "https://api.github.com/repos/hacs/default/contents/integration": 1,
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/branches/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://data-v2.hacs.xyz/integration/data.json": 1,
+        "https://data-v2.hacs.xyz/removed/repositories.json": 1
+    },
     "tests/test_config_flow.py::test_flow_with_activation_failure": {
         "https://github.com/login/device/code": 1,
         "https://github.com/login/oauth/access_token": 2

--- a/tests/scripts/data/test_generate_category_data.py
+++ b/tests/scripts/data/test_generate_category_data.py
@@ -1,4 +1,5 @@
 """Test generate category data."""
+
 import json
 
 from homeassistant.core import HomeAssistant
@@ -56,9 +57,7 @@ async def test_generate_category_data_single_repository(
                 category_test_data['repository']}/repositories.json",
         )
 
-    with open(
-        f"{OUTPUT_DIR}/summary.json", encoding="utf-8"
-    ) as file:
+    with open(f"{OUTPUT_DIR}/summary.json", encoding="utf-8") as file:
         snapshots.assert_match(
             safe_json_dumps(json.loads(file.read())),
             f"scripts/data/generate_category_data/single/{category_test_data['category']}/{
@@ -97,11 +96,92 @@ async def test_generate_category_data(
                 category_test_data['category']}/repositories.json",
         )
 
-    with open(
-        f"{OUTPUT_DIR}/summary.json", encoding="utf-8"
-    ) as file:
+    with open(f"{OUTPUT_DIR}/summary.json", encoding="utf-8") as file:
         snapshots.assert_match(
             safe_json_dumps(recursive_remove_key(json.loads(file.read()), ())),
             f"scripts/data/generate_category_data/{
+                category_test_data['category']}/summary.json",
+        )
+
+
+@pytest.mark.parametrize("category_test_data", [{"category": "integration"}])
+async def test_generate_category_data_with_prior_content(
+    hass: HomeAssistant,
+    response_mocker: ResponseMocker,
+    snapshots: SnapshotFixture,
+    category_test_data: CategoryTestData,
+):
+    """Test behaviour with prior content."""
+    response_mocker.add(
+        f"https://data-v2.hacs.xyz/{category_test_data['category']}/data.json",
+        MockedResponse(
+            content={
+                "1296269": {
+                    "description": "This your first repo!",
+                    "domain": "example",
+                    "downloads": 42,
+                    "etag_repository": "321",
+                    "full_name": "hacs-test-org/integration-basic",
+                    "last_updated": "2011-01-26T19:06:43Z",
+                    "last_version": "1.0.0",
+                    "manifest": {"name": "Proxy manifest"},
+                    "manifest_name": "Proxy manifest",
+                    "stargazers_count": 80,
+                    "topics": ["api", "atom", "electron", "octocat"],
+                }
+            }
+        ),
+    )
+    response_mocker.add(
+        "https://api.github.com/graphql",
+        MockedResponse(
+            content={
+                "data": {
+                    "repository": {
+                        "latestRelease": {
+                            "tagName": "1.0.0",
+                            "releaseAssets": {
+                                "nodes": [{"name": "basic.zip", "downloadCount": 4321}]
+                            },
+                        },
+                        "releases": {
+                            "nodes": [
+                                {
+                                    "tagName": "2.0.0b0",
+                                    "isPrerelease": True,
+                                    "releaseAssets": {
+                                        "nodes": [{"name": "basic.zip", "downloadCount": 1234}]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        ),
+    )
+    await generate_category_data(category_test_data["category"])
+
+    with open(f"{OUTPUT_DIR}/{category_test_data['category']}/data.json", encoding="utf-8") as file:
+        snapshots.assert_match(
+            safe_json_dumps(recursive_remove_key(
+                json.loads(file.read()), ("last_fetched",))),
+            f"scripts/data/generate_category_data_with_prior_content/{
+                category_test_data['category']}/data.json",
+        )
+
+    with open(
+        f"{OUTPUT_DIR}/{category_test_data['category']}/repositories.json", encoding="utf-8"
+    ) as file:
+        snapshots.assert_match(
+            safe_json_dumps(recursive_remove_key(json.loads(file.read()), ())),
+            f"scripts/data/generate_category_data_with_prior_content/{
+                category_test_data['category']}/repositories.json",
+        )
+
+    with open(f"{OUTPUT_DIR}/summary.json", encoding="utf-8") as file:
+        snapshots.assert_match(
+            safe_json_dumps(recursive_remove_key(json.loads(file.read()), ())),
+            f"scripts/data/generate_category_data_with_prior_content/{
                 category_test_data['category']}/summary.json",
         )

--- a/tests/snapshots/diagnostics/base.json
+++ b/tests/snapshots/diagnostics/base.json
@@ -131,6 +131,7 @@
                 "manifest_name": "HACS",
                 "new": false,
                 "open_issues": 2,
+                "prerelease": null,
                 "published_tags": [],
                 "releases": true,
                 "selected_tag": null,

--- a/tests/snapshots/diagnostics/exception.json
+++ b/tests/snapshots/diagnostics/exception.json
@@ -74,6 +74,7 @@
                 "manifest_name": "HACS",
                 "new": false,
                 "open_issues": 2,
+                "prerelease": null,
                 "published_tags": [],
                 "releases": true,
                 "selected_tag": null,

--- a/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/data.json
+++ b/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/data.json
@@ -1,0 +1,43 @@
+{
+    "1296269": {
+        "description": "This your first repo!",
+        "domain": "example",
+        "downloads": 4321,
+        "etag_repository": "321",
+        "full_name": "hacs-test-org/integration-basic",
+        "last_updated": "2011-01-26T19:06:43Z",
+        "last_version": "1.0.0",
+        "manifest": {
+            "name": "Proxy manifest"
+        },
+        "manifest_name": "Proxy manifest",
+        "prerelease": "2.0.0b0",
+        "stargazers_count": 80,
+        "topics": [
+            "api",
+            "atom",
+            "electron",
+            "octocat"
+        ]
+    },
+    "91296269": {
+        "description": "This your first repo!",
+        "domain": "example",
+        "downloads": 42,
+        "etag_repository": "321",
+        "full_name": "hacs-test-org/integration-basic-custom",
+        "last_updated": "2011-01-26T19:06:43Z",
+        "last_version": "1.0.0",
+        "manifest": {
+            "name": "Proxy manifest"
+        },
+        "manifest_name": "Proxy manifest",
+        "stargazers_count": 80,
+        "topics": [
+            "api",
+            "atom",
+            "electron",
+            "octocat"
+        ]
+    }
+}

--- a/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/repositories.json
+++ b/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/repositories.json
@@ -1,0 +1,4 @@
+[
+    "hacs-test-org/integration-basic",
+    "hacs-test-org/integration-basic-custom"
+]

--- a/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/summary.json
+++ b/tests/snapshots/scripts/data/generate_category_data_with_prior_content/integration/summary.json
@@ -1,0 +1,19 @@
+{
+    "changed": 2,
+    "changed_pct": 100,
+    "current_count": 1,
+    "diff": 1,
+    "new_count": 2,
+    "rate_limit": {
+        "core": {
+            "limit": 5000,
+            "reset": 1691591363,
+            "used": 1
+        },
+        "graphql": {
+            "limit": 5000,
+            "reset": 1691593228,
+            "used": 7
+        }
+    }
+}


### PR DESCRIPTION
Attempt 2...

#3841 had to be reverted (in #3846) because of an issue with releases that were not latest, and not draft/pre.
That information was not in the REST API, so this had to be changed to using GraphQL...