### PR TITLE
Fix Type hint

### DIFF
--- a/custom_components/hacs/data_client.py
+++ b/custom_components/hacs/data_client.py
@@ -61,7 +61,7 @@ class HacsDataClient:
 
         return await response.json()
 
-    async def get_data(self, section: str | None, *, validate: bool) -> dict[str, dict[str, Any]]:
+    async def get_data(self, section: str | None, *, validate: bool) -> dict[str, dict[str, Any]] | list[str]:
         """Get data."""
         data = await self._do_request(filename="data.json", section=section)
         if not validate:


### PR DESCRIPTION
## Description
Fix a type check warning reported by Pyre@Google, which was outdated after code modification.

## Detail
update the return type of function `get_data` from `dict[str, dict[str, Any]]` to `dict[str, dict[str, Any]] | list[str]`, since it could return `list` after commit https://github.com/hacs/integration/commit/e7929b75a1a76d667ceb028225559df5638bd625