### PR TITLE
Show all pending updates

### DIFF
--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -410,8 +410,6 @@ class HacsRepository:
     @property
     def pending_update(self) -> bool:
         """Return True if pending update."""
-        if not self.can_download:
-            return False
         if self.data.installed:
             if self.data.selected_tag is not None:
                 if self.data.selected_tag == self.data.default_branch:

--- a/tests/repositories/test_display_status.py
+++ b/tests/repositories/test_display_status.py
@@ -1,0 +1,33 @@
+"""Configuration Test Suite: can install."""
+# pylint: disable=missing-docstring
+from awesomeversion import AwesomeVersion
+
+from custom_components.hacs.base import HacsBase
+
+
+def test_display_status(hacs: HacsBase):
+    repository = hacs.repositories.get_by_full_name(
+        "hacs-test-org/integration-basic")
+
+    assert repository.display_status == "default"
+
+    repository.data.new = True
+    assert repository.display_status == "new"
+    repository.data.new = False
+
+    repository.pending_restart = True
+    assert repository.display_status == "pending-restart"
+    repository.pending_restart = False
+
+    repository.data.installed = True
+    repository.data.installed_version = "1"
+    repository.data.last_version = "2"
+    repository.data.releases = True
+    assert repository.display_status == "pending-upgrade"
+
+    hacs.core.ha_version = AwesomeVersion("0.0.0")
+    repository.repository_manifest.homeassistant = "1.0.0"
+    assert repository.display_status == "pending-upgrade"
+
+    repository.data.last_version = "1"
+    assert repository.display_status == "installed"

--- a/tests/snapshots/api-usage/tests/repositories/test_display_statustest-display-status.json
+++ b/tests/snapshots/api-usage/tests/repositories/test_display_statustest-display-status.json
@@ -1,0 +1,9 @@
+{
+    "tests/repositories/test_display_status.py::test_display_status": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1
+    }
+}


### PR DESCRIPTION
Non-downloadable updates were previously hidden as updates in the HACS UI.
This was wrong. Even if you do not meet the minimum requirements for the update, it still exists and is pending.