### PR TITLE
Update documentation link in manifest

### DIFF
--- a/custom_components/hacs/manifest.json
+++ b/custom_components/hacs/manifest.json
@@ -16,7 +16,7 @@
         "lovelace",
         "repairs"
     ],
-    "documentation": "https://hacs.xyz/docs/use/configuration/options",
+    "documentation": "https://hacs.xyz/docs/use/",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/hacs/integration/issues",
     "requirements": [

--- a/custom_components/hacs/manifest.json
+++ b/custom_components/hacs/manifest.json
@@ -16,7 +16,7 @@
         "lovelace",
         "repairs"
     ],
-    "documentation": "https://hacs.xyz/docs/configuration/start",
+    "documentation": "https://hacs.xyz/docs/use/configuration/options",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/hacs/integration/issues",
     "requirements": [


### PR DESCRIPTION
This PR will update the documentation link as the current one leads to a 404 error page. Was unsure whether I had to bump up the version as well in line 25.

**Background:**

While setting up HACS options, I clicked on the help icon and it lead me to this url https://hacs.xyz/docs/configuration/start, which displayed a 404 page.

Given a quick search on the repo had revealed this is the only place where the url was referenced, I thought to do a quick PR to update the documentation url.

![Capture](https://github.com/user-attachments/assets/beeaaba8-a6b4-4ea2-80c9-b9f911e9bd78)
