### PR TITLE
Add devcontainer features to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  labels:
-    - "pr: dependency-update"
-  schedule:
-    interval: weekly
-    time: "06:00"
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  labels:
-    - "pr: dependency-update"
-  schedule:
-    interval: weekly
-    time: "06:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
I don't use devcontainers myself yet but was requested in https://github.com/hacs/addons/pull/12.