### PR TITLE
Adjust string to fix hassfest error

### DIFF
--- a/custom_components/hacs/translations/en.json
+++ b/custom_components/hacs/translations/en.json
@@ -30,7 +30,7 @@
             }
         },
         "progress": {
-            "wait_for_device": "1. Open {url} \n2. Paste the following key to authorize HACS: \n```\n{code}\n```\n"
+            "wait_for_device": "1. Open {url} \n2. Paste the following key to authorize HACS: \n```\n{code}\n```"
         }
     },
     "options": {


### PR DESCRIPTION
```
Integration hacs - /github/workspace/custom_components/hacs:
Error: R] [TRANSLATIONS] Invalid translations/en.json: the string should not contain leading or trailing spaces for dictionary value @ data['config']['progress']['wait_for_device']. Got '1. Open {url} \n2. Paste the following key to authorize HACS: \n```\n{code}\n```\n'
```

Became a problem after https://github.com/home-assistant/core/pull/126446