### PR TITLE
Do not set config_entry in option flow if HA > 24.11.99

### DIFF
--- a/custom_components/hacs/config_flow.py
+++ b/custom_components/hacs/config_flow.py
@@ -196,7 +196,8 @@ class HacsOptionsFlowHandler(OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize HACS options flow."""
-        self.config_entry = config_entry
+        if AwesomeVersion(HAVERSION) < "2024.11.99":
+            self.config_entry = config_entry
 
     async def async_step_init(self, _user_input=None):
         """Manage the options."""


### PR DESCRIPTION
No longer allowed after <https://github.com/home-assistant/core/pull/129562> and <https://github.com/home-assistant/developers.home-assistant/pull/2435>