### PR TITLE
fix: use authed method to get manifest file

### DIFF
--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -183,6 +183,7 @@ class HacsIntegrationRepository(HacsRepository):
         if not manifest_path in (x.full_path for x in self.tree):
             raise HacsException(f"No {RepositoryFile.MAINIFEST_JSON} file found '{manifest_path}'")
 
+        self.logger.debug("%s Getting manifest.json for ref=%s", self.string, ref)
         response = await self.hacs.async_github_api_method(
             method=self.hacs.githubapi.repos.contents.get,
             repository=self.data.full_name,

--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -183,12 +183,13 @@ class HacsIntegrationRepository(HacsRepository):
         if not manifest_path in (x.full_path for x in self.tree):
             raise HacsException(f"No {RepositoryFile.MAINIFEST_JSON} file found '{manifest_path}'")
 
+        ref = ref or self.version_to_download()
         self.logger.debug("%s Getting manifest.json for ref=%s", self.string, ref)
         response = await self.hacs.async_github_api_method(
             method=self.hacs.githubapi.repos.contents.get,
             repository=self.data.full_name,
             path=manifest_path,
-            **{"params": {"ref": ref or self.version_to_download()}},
+            **{"params": {"ref": ref}},
         )
         if response:
             return json_loads(decode_content(response.data.content))

--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -191,27 +191,3 @@ class HacsIntegrationRepository(HacsRepository):
         )
         if response:
             return json_loads(decode_content(response.data.content))
-
-    async def get_integration_manifest(self, *, version: str, **kwargs) -> dict[str, Any] | None:
-        """Get the content of the manifest.json file."""
-        manifest_path = (
-            "manifest.json"
-            if self.repository_manifest.content_in_root
-            else f"{self.content.path.remote}/{RepositoryFile.MAINIFEST_JSON}"
-        )
-
-        if manifest_path not in (x.full_path for x in self.tree):
-            raise HacsException(f"No {RepositoryFile.MAINIFEST_JSON} file found '{manifest_path}'")
-
-        self.logger.debug("%s Getting manifest.json for version=%s", self.string, version)
-        try:
-            result = await self.hacs.async_download_file(
-                f"https://raw.githubusercontent.com/{
-                    self.data.full_name}/{version}/{manifest_path}",
-                nolog=True,
-            )
-            if result is None:
-                return None
-            return json_loads(result)
-        except Exception:  # pylint: disable=broad-except
-            return None

--- a/custom_components/hacs/validate/integration_manifest.py
+++ b/custom_components/hacs/validate/integration_manifest.py
@@ -32,7 +32,7 @@ class Validator(ActionValidationBase):
                 f"The repository has no '{RepositoryFile.MAINIFEST_JSON}' file"
             )
 
-        content = await self.repository.get_integration_manifest(version=self.repository.ref)
+        content = await self.repository.async_get_integration_manifest(ref=self.repository.ref)
         try:
             INTEGRATION_MANIFEST_JSON_SCHEMA(content)
         except Invalid as exception:

--- a/tests/action/test_hacs_action_integration.py
+++ b/tests/action/test_hacs_action_integration.py
@@ -46,10 +46,14 @@ async def test_hacs_action_integration(
         response=MockedResponse(status=200, content={"custom": ["example"]}),
     )
     response_mocker.add(
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json",
+        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json",
         response=MockedResponse(
             status=200,
-            content=json.dumps({**basemanifest, **manifest}),
+            content={
+                "content": base64.b64encode(
+                    json.dumps({**basemanifest, **manifest}).encode()
+                ).decode()
+            },
             keep=True,
         ),
     )

--- a/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
@@ -1,6 +1,6 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
@@ -1,6 +1,5 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for version=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
@@ -1,5 +1,7 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
@@ -1,6 +1,6 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
@@ -1,6 +1,5 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for version=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
@@ -1,5 +1,7 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
+++ b/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
@@ -1,6 +1,6 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed

--- a/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
+++ b/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
@@ -1,6 +1,5 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
-<Integration hacs-test-org/integration-basic> Getting manifest.json for version=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
+++ b/tests/snapshots/action/test_hacs_action_integration/valid_manifest1.log
@@ -1,5 +1,7 @@
 <Integration hacs-test-org/integration-basic> Checking repository.
 <Integration hacs-test-org/integration-basic> Running checks against main
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=None
+<Integration hacs-test-org/integration-basic> Getting manifest.json for ref=main
 <Validation archived> completed
 <Validation brands> completed
 <Validation description> completed

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-documentation-manifest0-false.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-documentation-manifest0-false.json
@@ -1,11 +1,10 @@
 {
     "tests/action/test_hacs_action_integration.py::test_hacs_action_integration[bad_documentation-manifest0-False]": {
         "https://api.github.com/repos/hacs-test-org/integration-basic": 2,
-        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/contents/hacs.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/git/trees/main": 1,
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
-        "https://brands.home-assistant.io/domains.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1
+        "https://brands.home-assistant.io/domains.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-issue-tracker-manifest1-false.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-issue-tracker-manifest1-false.json
@@ -1,11 +1,10 @@
 {
     "tests/action/test_hacs_action_integration.py::test_hacs_action_integration[bad_issue_tracker-manifest1-False]": {
         "https://api.github.com/repos/hacs-test-org/integration-basic": 2,
-        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/contents/hacs.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/git/trees/main": 1,
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
-        "https://brands.home-assistant.io/domains.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1
+        "https://brands.home-assistant.io/domains.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-valid-manifest1-manifest2-true.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-valid-manifest1-manifest2-true.json
@@ -1,11 +1,10 @@
 {
     "tests/action/test_hacs_action_integration.py::test_hacs_action_integration[valid_manifest1-manifest2-True]": {
         "https://api.github.com/repos/hacs-test-org/integration-basic": 2,
-        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 1,
+        "https://api.github.com/repos/hacs-test-org/integration-basic/contents/custom_components/example/manifest.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/contents/hacs.json": 2,
         "https://api.github.com/repos/hacs-test-org/integration-basic/git/trees/main": 1,
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
-        "https://brands.home-assistant.io/domains.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1
+        "https://brands.home-assistant.io/domains.json": 1
     }
 }

--- a/tests/validate/test_integration_manifest_check.py
+++ b/tests/validate/test_integration_manifest_check.py
@@ -43,7 +43,7 @@ async def test_hacs_manifest_with_invalid_manifest(repository_integration):
     async def _async_get_integration_manifest(**__):
         return {"not": "valid"}
 
-    repository_integration.get_integration_manifest = _async_get_integration_manifest
+    repository_integration.async_get_integration_manifest = _async_get_integration_manifest
     check = Validator(repository_integration)
     await check.execute_validation()
     assert check.failed

--- a/tests/validate/test_integration_manifest_check.py
+++ b/tests/validate/test_integration_manifest_check.py
@@ -26,7 +26,7 @@ async def test_integration_manifest_with_valid_manifest(repository_integration):
             "version": "1.0.0",
         }
 
-    repository_integration.get_integration_manifest = _async_get_integration_manifest
+    repository_integration.async_get_integration_manifest = _async_get_integration_manifest
 
     check = Validator(repository_integration)
     await check.execute_validation()


### PR DESCRIPTION
Removed the duplicate method `get_integration_manifest`. This resolves auth issues I was seeing with a private repo.

This does mean a duplicate call being made though - is this something I should look to resolve?