### PR TITLE
Make sure that the ref is used when collecting integration manifest

### DIFF
--- a/custom_components/hacs/repositories/integration.py
+++ b/custom_components/hacs/repositories/integration.py
@@ -92,7 +92,7 @@ class HacsIntegrationRepository(HacsRepository):
             self.content.path.remote = f"custom_components/{name}"
 
         # Get the content of manifest.json
-        if manifest := await self.async_get_integration_manifest():
+        if manifest := await self.async_get_integration_manifest(self.ref):
             try:
                 self.integration_manifest = manifest
                 self.data.authors = manifest.get("codeowners", [])


### PR DESCRIPTION
Fixes #4229 

.. Or at least did locally, I had to patch a few things to make the action run in my local environment.

You could also just make `async_get_integration_manifest` not take ref as an argument at all and take it from the `self` object but I didn't spend a whole lot of time seeing how else it is used.

I believe this will now work - I had a little trouble detangling https://github.com/hacs/integration/blob/main/action/action.py#L115-L136 to figure out whether or not `ref` will get correctly set on pushes and pull requests and because the action lives in `action` and not this repository it wasn't immediately clear to me how to wire this up to my runs.