### PR TITLE
Remove python 3.12 from dev tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,7 +55,6 @@ jobs:
         homeassistant-version:
           - "dev"
         python-version:
-          - "3.12"
           - "3.13"
     steps:
       - name: 📥 Checkout the repository


### PR DESCRIPTION
Home Assistant dev no longer supports running on Python 3.12