### PR TITLE
Allow ignoring restart repairs

### DIFF
--- a/custom_components/hacs/translations/en.json
+++ b/custom_components/hacs/translations/en.json
@@ -58,10 +58,17 @@
             "title": "Restart required",
             "fix_flow": {
                 "step": {
-                    "confirm_restart": {
+                    "init": {
                         "title": "Restart required",
-                        "description": "Restart of Home Assistant is required to finish download/update of {name}, click submit to restart now."
+                        "description": "Restart of Home Assistant is required to finish download/update of {name}.",
+                        "menu_options": {
+                            "restart": "Restart Now",
+                            "ignore": "Ignore Repair"
+                        }
                     }
+                },
+                "abort": {
+                    "issue_ignored": "Restart repair for {name} update has been ignored. You will have to restart later, if you want the update to take effect."
                 }
             }
         },


### PR DESCRIPTION
This PR introduces the ability to dismiss the restart repair without restarting home assistant

![image](https://github.com/user-attachments/assets/e5ff61f9-161c-41b3-a586-40c491963568)

The motivation behind it is that I often find myself constantly back to that yellow warning in the sidebar with the strong urge to do something about it, however I usually can't because there's some kind of long-running script waiting for a trigger that would not survive the restart.

![image](https://github.com/user-attachments/assets/6927b019-a192-4c22-accb-d364678264c1)


While it does say Ignore, it actually calls `async_delete_issue` because otherwise, if the user were to install the same version again, the repair would never pop up again, as it would remain ignored in the registry.