### PR TITLE
Set default workflow permissions

### DIFF
--- a/.github/workflows/action-container.yml
+++ b/.github/workflows/action-container.yml
@@ -23,6 +23,8 @@ concurrency:
   group: container-build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -29,6 +29,8 @@ on:
 concurrency:
   group: category-data
 
+permissions: {}
+
 jobs:
   generate-matrix:
     name: Generate matrix

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,6 +12,8 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,6 +8,8 @@ concurrency:
   group: lock-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   release_zip_file:
     name: Publish HACS zip file asset

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,6 +12,8 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   legacy:
     name: With pytest with Home Assistant (min. supported version)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,8 @@ concurrency:
   cancel-in-progress: true
   group: validate-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   preflight:
     if: ${{ github.repository == 'hacs/integration' }}


### PR DESCRIPTION
The repository settings already restricted the default to read, but that is not checked by tools or forks, so this PR updates all workflows to reflect that setting.