### PR TITLE
Only use cached manifest if there is no ref supplied

### DIFF
--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -1396,7 +1396,7 @@ class HacsRepository:
                 )
             return
 
-        if ref is None or ref == "":
+        if not ref:
             target_manifest = self.repository_manifest
         else:
             target_manifest = await self.get_hacs_json(version=ref)


### PR DESCRIPTION
When doing updates, we ensure we can apply the update (in range of allowed HACS/HA versions).

This check wrongly assumed to use the cached data in some cases; this PR fixes that, so if a ref is supplied, we always get the new content.