### PR TITLE
Fixup misleading nomenclature: s/frontend cache/client cache/g

### DIFF
--- a/custom_components/hacs/update.py
+++ b/custom_components/hacs/update.py
@@ -129,7 +129,7 @@ class HacsRepositoryUpdateEntity(HacsRepositoryEntity, UpdateEntity):
             if self.repository.data.category == HacsCategory.PLUGIN:
                 release_notes += (
                     "\n\n<ha-alert alert-type='warning'>You need to manually"
-                    " clear the frontend cache after updating.</ha-alert>\n\n"
+                    " clear the client cache after updating.</ha-alert>\n\n"
                 )
 
         return release_notes.replace("\n#", "\n\n#")


### PR DESCRIPTION
This commit replaces every instance of a misleading reference to a "frontend cache" where there is no such thing with a correct, however generalized, reference to the "client cache." There is only one such reference in this repository.

In objective fact, a "frontend cache" is a term reserved for server-side caching reverse proxies centralized on and attributable to a frontend itself. No such resource exists in any Home Assistant deployment. This incorrect use of terms is confusing and misleading, and therefore is herein replaced.

The only relevant cache is attributable to the client, whether it is a browser or whether it is a dedicated platform client. This change categorically prevents the mistaken apprehension that any server-side cache attributable to the frontend requires resetting, and at the very least, is *less incorrect.*

cf. https://community.home-assistant.io/t/how-to-clear-the-frontend-cache/670491/91

This pull request is part of a set against the following repositories (crosslinks may be updated after the PR is opened):
  - home-assistant/android
  - home-assistant/iOS
  - hacs/integration