### PR TITLE
Improve frontend cache message

### DIFF
--- a/custom_components/hacs/update.py
+++ b/custom_components/hacs/update.py
@@ -129,7 +129,7 @@ class HacsRepositoryUpdateEntity(HacsRepositoryEntity, UpdateEntity):
             if self.repository.data.category == HacsCategory.PLUGIN:
                 release_notes += (
                     "\n\n<ha-alert alert-type='warning'>You need to manually"
-                    " clear the browser or app cache after updating.</ha-alert>\n\n"
+                    " clear the browser cache or app client cache after updating.</ha-alert>\n\n"
                 )
 
         return release_notes.replace("\n#", "\n\n#")


### PR DESCRIPTION
When I ran across this, I was confused and found that other people are too: https://community.home-assistant.io/t/how-to-clear-the-frontend-cache/670491

This change uses "browser or app" because clearing a browser cache is known to more users (and more easily searchable).

Previous effort:
- https://github.com/hacs/integration/pull/4788
- https://github.com/home-assistant/iOS/pull/3784
- https://github.com/home-assistant/android/pull/5711