### PR TITLE
Add PowerClimate integration to HACS default store

### DIFF
--- a/integration/marnixt-PowerClimate.json
+++ b/integration/marnixt-PowerClimate.json
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 {
   "name": "PowerClimate",
   "fullname": "marnixt/PowerClimate",
@@ -9,30 +8,10 @@
   "documentation": "https://github.com/marnixt/PowerClimate",
   "issue_tracker": "https://github.com/marnixt/PowerClimate/issues",
   "content_in_root": false,
-  "zip_release": true,
+  "zip_release": false,
   "render_readme": true,
   "categories": ["integration"],
   "domains": ["powerclimate"],
   "default_branch": "main",
   "homeassistant": "2024.11.0"
 }
-=======
-﻿{
-  "name": "PowerClimate",
-  "fullname": "marnixt/PowerClimate",
-  "description": "Manage multiple heat-pump climate devices and coordinate setpoints using temperature offsets.",
-  "owner": "marnixt",
-  "repo": "PowerClimate",
-  "homepage": "https://github.com/marnixt/PowerClimate",
-  "documentation": "https://github.com/marnixt/PowerClimate",
-  "issue_tracker": "https://github.com/marnixt/PowerClimate/issues",
-  "content_in_root": false,
-  "zip_release": true,
-  "render_readme": true,
-  "categories": ["integration"],
-  "domains": ["powerclimate"],
-  "default_branch": "main",
-  "homeassistant": "2024.11.0"
-}
-
->>>>>>> 9992ee6 (Add PowerClimate integration metadata for HACS default store)


### PR DESCRIPTION
Add integration listing for marnixt/PowerClimate. See repository HACS_INTEGRATION_INFO.json for metadata.