### PR TITLE
Remove pycares constraint

### DIFF
--- a/requirements_action.txt
+++ b/requirements_action.txt
@@ -1,4 +1,4 @@
 aiogithubapi>=24.6.0
 homeassistant==2025.11.3
 # https://github.com/aio-libs/aiodns/issues/214
-pycares<5
+# pycares<5


### PR DESCRIPTION
Required to allow HACS installation