### PR TITLE
Remove Python 3.13 from the test matrix in pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -89,7 +89,7 @@ jobs:
         run: scripts/test
 
       - name: 📤 Upload coverage to Codecov
-        if: ${{ matrix.python-version == '3.13' }}
+        if: ${{ matrix.python-version == '3.14' }}
         run: |
           scripts/coverage
           curl -sfSL https://codecov.io/bash | bash -


### PR DESCRIPTION
Home Assistant dev now requires Python 3.14