### PR TITLE
Enable fail-fast strategy in generate data workflow matrix

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -53,7 +53,7 @@ jobs:
     if: github.repository == 'hacs/integration'
     name: Generate ${{ matrix.category }} data
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         category: ${{ fromJSON( needs.generate-matrix.outputs.categories )}}
     steps:


### PR DESCRIPTION
These failures are generally due to GitHub issues.
We should fast abort all on any issue, and let it run fully on the next scheduled run instead.