### PR TITLE
fix: use local brands API for update entity picture

### DIFF
--- a/custom_components/hacs/update.py
+++ b/custom_components/hacs/update.py
@@ -76,7 +76,7 @@ class HacsRepositoryUpdateEntity(HacsRepositoryEntity, UpdateEntity):
         ):
             return None
 
-        return f"https://brands.home-assistant.io/_/{self.repository.data.domain}/icon.png"
+        return f"/api/brands/integration/{self.repository.data.domain}/icon.png"
 
     async def async_install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         """Install an update."""


### PR DESCRIPTION
## Summary

Since **HA 2026.3.0**, brand images are served through the local HA API (`/api/brands/integration/{domain}/icon.png`) instead of being fetched directly from the external CDN by the browser. Custom integrations can now ship their own brand images in a `brand/` subdirectory ([announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)).

However, `update.py` still constructs the entity picture URL pointing at the CDN:

```python
# before
return f"https://brands.home-assistant.io/_/{self.repository.data.domain}/icon.png"
```

The CDN returns a generic placeholder PNG (200 OK, ~3 KB) for any domain not listed in the official brands repository. HA's frontend detects this placeholder and displays **"icon not available"** — so custom integrations that correctly ship a `brand/` directory still show no icon in the Updates card.

## Fix

```python
# after
return f"/api/brands/integration/{self.repository.data.domain}/icon.png"
```

Using the relative local API path routes the request through HA's backend, which serves from the integration's local `brand/` directory when present, and falls back to the CDN for official integrations. This fixes icon display for all custom integrations that follow the HA 2026.3 spec.

## Impact

- Official integrations (in the brands CDN): no change — local API proxies to CDN as before
- Custom integrations with a `brand/` directory: icon now shows correctly
- Custom integrations without a `brand/` directory: HA returns a fallback, same as before