### PR TITLE
Remove redundant test execution from coverage script

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -4,7 +4,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-bash scripts/test > /dev/null
 python3 -m \
     coverage \
     report \


### PR DESCRIPTION
## Summary
Removed the redundant `bash scripts/test > /dev/null` command from the coverage script to streamline the coverage reporting workflow.

## Key Changes
- Removed the test execution step from `scripts/coverage` that was suppressing output to `/dev/null`

## Implementation Details
The coverage script now directly runs the coverage report without first executing the test suite. This change assumes that tests are run separately before coverage analysis, eliminating unnecessary duplication and improving script efficiency. The coverage report generation remains unchanged.

https://claude.ai/code/session_016t9V2XhVCW9L3arK5EUyBJ