### PR TITLE
Add custom Renovate manager for license validation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,14 @@
       "matchFileNames": ["requirements_core_min.txt"],
       "enabled": false
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["custom_components/hacs/validate/license.py"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+ = \"(?<currentDigest>[a-f0-9]+)\"\\s+# (?<currentValue>\\S+)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
This change adds a custom Renovate manager configuration to enable automated dependency updates for hash-based dependencies in the license validation module.

## Key Changes
- Added a custom regex-based Renovate manager that targets `custom_components/hacs/validate/license.py`
- Configured the manager to parse and update dependencies specified with a custom comment format: `# renovate: datasource=<datasource> depName=<depName>`
- The regex pattern extracts the datasource, dependency name, current digest (hash), and current version from specially formatted variable assignments

## Implementation Details
The custom manager uses a regex pattern to identify and track dependencies that are defined as string constants with associated metadata comments. This allows Renovate to:
- Detect when new versions are available for these dependencies
- Automatically create pull requests to update the hash values and version comments
- Maintain consistency with the project's dependency management strategy for license validation components

https://claude.ai/code/session_01LmsJWyEew9BpDb9ogUAVU1