### PR TITLE
Optimize license validation by caching popular OSI licenses

### DIFF
--- a/custom_components/hacs/validate/license.py
+++ b/custom_components/hacs/validate/license.py
@@ -16,6 +16,27 @@ SPDX_LICENSE_LIST_URL = (
     f"{SPDX_LICENSE_LIST_COMMIT}/json/licenses.json"
 )
 
+# OSI "Popular / Strong Community" licenses.
+# https://opensource.org/licenses?categories=popular-strong-community
+# Cached so the common case avoids fetching the full SPDX license list; only
+# uncommon licenses fall back to the fetch below. SPDX IDs use the forms
+# returned by GitHub's license API.
+POPULAR_OSI_APPROVED_LICENSES = frozenset(
+    {
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "CDDL-1.0",
+        "EPL-2.0",
+        "GPL-2.0",
+        "GPL-3.0",
+        "LGPL-2.1",
+        "LGPL-3.0",
+        "MIT",
+        "MPL-2.0",
+    }
+)
+
 
 async def async_setup_validator(repository: HacsRepository) -> Validator:
     """Set up this validator."""
@@ -40,6 +61,13 @@ class Validator(ActionValidationBase):
             raise ValidationException(
                 "The repository license could not be identified (SPDX: NOASSERTION)"
             )
+
+        if spdx_id in POPULAR_OSI_APPROVED_LICENSES:
+            self.repository.logger.debug(
+                "The repository has a popular OSI-approved license: %s",
+                license_info.get("name"),
+            )
+            return
 
         result = await self.hacs.async_download_file(SPDX_LICENSE_LIST_URL, handle_rate_limit=True)
         if result is None:

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-documentation.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-documentation.json
@@ -7,7 +7,6 @@
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
         "https://brands.home-assistant.io/domains.json": 1,
         "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-issue-tracker.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-bad-issue-tracker.json
@@ -7,7 +7,6 @@
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
         "https://brands.home-assistant.io/domains.json": 1,
         "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-no-releases.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-no-releases.json
@@ -7,7 +7,6 @@
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
         "https://brands.home-assistant.io/domains.json": 1,
         "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-releases-without-assets.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-releases-without-assets.json
@@ -7,7 +7,6 @@
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
         "https://brands.home-assistant.io/domains.json": 1,
         "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-valid-manifest.json
+++ b/tests/snapshots/api-usage/tests/action/test_hacs_action_integrationtest-hacs-action-integration-valid-manifest.json
@@ -7,7 +7,6 @@
         "https://api.github.com/repos/hacs-test-org/integration-basic/releases": 1,
         "https://brands.home-assistant.io/domains.json": 1,
         "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/custom_components/example/manifest.json": 1,
-        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://raw.githubusercontent.com/hacs-test-org/integration-basic/main/hacs.json": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-apache-2-0.json
+++ b/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-apache-2-0.json
@@ -1,0 +1,9 @@
+{
+    "tests/validate/test_license.py::test_repository_popular_license_skips_fetch[Apache-2.0]": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1
+    }
+}

--- a/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-gpl-3-0.json
+++ b/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-gpl-3-0.json
@@ -1,10 +1,9 @@
 {
-    "tests/validate/test_license.py::test_repository_osi_approved_license[MIT]": {
+    "tests/validate/test_license.py::test_repository_popular_license_skips_fetch[GPL-3.0]": {
         "https://api.github.com/repos/hacs/integration": 1,
         "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
         "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
         "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
-        "https://api.github.com/repos/hacs/integration/releases": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://api.github.com/repos/hacs/integration/releases": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-mit.json
+++ b/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-popular-license-skips-fetch-mit.json
@@ -1,10 +1,9 @@
 {
-    "tests/validate/test_license.py::test_repository_osi_approved_license[GPL-3.0]": {
+    "tests/validate/test_license.py::test_repository_popular_license_skips_fetch[MIT]": {
         "https://api.github.com/repos/hacs/integration": 1,
         "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
         "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
         "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
-        "https://api.github.com/repos/hacs/integration/releases": 1,
-        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+        "https://api.github.com/repos/hacs/integration/releases": 1
     }
 }

--- a/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-uncommon-osi-license.json
+++ b/tests/snapshots/api-usage/tests/validate/test_licensetest-repository-uncommon-osi-license.json
@@ -1,0 +1,10 @@
+{
+    "tests/validate/test_license.py::test_repository_uncommon_osi_license": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://raw.githubusercontent.com/spdx/license-list-data/c4a7237ec8f4654e867546f9f409749300f1bf4c/json/licenses.json": 1
+    }
+}

--- a/tests/validate/test_license.py
+++ b/tests/validate/test_license.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -53,15 +54,21 @@ async def test_spdx_license_list_fetch_failure(repository, response_mocker: Resp
     response_mocker.add(SPDX_LICENSE_LIST_URL, MockedResponse(status=500))
     repository.repository_object = MagicMock()
     repository.repository_object.attributes = {
-        "license": {"key": "mit", "name": "MIT License", "spdx_id": "MIT"},
+        # An uncommon (non-cached) license so the check falls back to the fetch.
+        "license": {"key": "isc", "name": "ISC License", "spdx_id": "ISC"},
     }
     check = Validator(repository)
     await check.execute_validation()
     assert check.failed
 
 
-@pytest.mark.parametrize("spdx_id", ["MIT", "GPL-3.0"])
-async def test_repository_osi_approved_license(repository, spdx_id):
+@pytest.mark.parametrize("spdx_id", ["MIT", "Apache-2.0", "GPL-3.0"])
+async def test_repository_popular_license_skips_fetch(
+    repository, response_mocker: ResponseMocker, spdx_id
+):
+    # A popular license is cached and must pass without depending on the SPDX
+    # list fetch, so even a broken fetch (500) must not affect the result.
+    response_mocker.add(SPDX_LICENSE_LIST_URL, MockedResponse(status=500))
     repository.repository_object = MagicMock()
     repository.repository_object.attributes = {
         "license": {
@@ -69,6 +76,24 @@ async def test_repository_osi_approved_license(repository, spdx_id):
             "name": f"License {spdx_id}",
             "spdx_id": spdx_id,
         },
+    }
+    check = Validator(repository)
+    await check.execute_validation()
+    assert not check.failed
+
+
+async def test_repository_uncommon_osi_license(repository, response_mocker: ResponseMocker):
+    # An uncommon OSI-approved license is not cached, so it falls back to the
+    # fetched SPDX list to be validated.
+    response_mocker.add(
+        SPDX_LICENSE_LIST_URL,
+        MockedResponse(
+            content=json.dumps({"licenses": [{"licenseId": "ISC", "isOsiApproved": True}]})
+        ),
+    )
+    repository.repository_object = MagicMock()
+    repository.repository_object.attributes = {
+        "license": {"key": "isc", "name": "ISC License", "spdx_id": "ISC"},
     }
     check = Validator(repository)
     await check.execute_validation()


### PR DESCRIPTION
## Summary
This change optimizes the license validation process by caching popular OSI-approved licenses locally, avoiding unnecessary fetches of the full SPDX license list for common licenses.

## Key Changes
- **Added `POPULAR_OSI_APPROVED_LICENSES` cache**: Created a frozenset of 11 popular OSI-approved licenses (Apache-2.0, BSD-2-Clause, BSD-3-Clause, CDDL-1.0, EPL-2.0, GPL-2.0, GPL-3.0, LGPL-2.1, LGPL-3.0, MIT, MPL-2.0) based on the OSI "Popular / Strong Community" category
- **Early return for cached licenses**: Modified `async_validate()` to return early when a repository uses a popular license, skipping the SPDX list fetch entirely
- **Improved test coverage**: 
  - Renamed `test_repository_osi_approved_license` to `test_repository_popular_license_skips_fetch` to better reflect its purpose
  - Added `Apache-2.0` to the parametrized test cases
  - Added new `test_repository_uncommon_osi_license` test to verify that uncommon licenses still fall back to fetching the SPDX list
  - Updated `test_spdx_license_list_fetch_failure` to use ISC license (uncommon) instead of MIT to properly test the fetch failure path

## Implementation Details
- The cache covers the most commonly used open-source licenses, reducing API calls for the typical case
- Uncommon licenses still trigger the full SPDX list fetch, ensuring comprehensive validation coverage
- The implementation maintains backward compatibility while improving performance for popular licenses

https://claude.ai/code/session_01QNegnooqm5jigRDLR9ydyj