### PR TITLE
Run data generation on Python 3.14 with Home Assistant 2026.6.0

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt
@@ -230,7 +230,7 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: |
             requirements_base.txt

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,5 @@
 aiogithubapi>=21.11.0
 aiohttp>=3.8.3,<4.0
-aiohttp_cors==0.7.0
 async-timeout>=4.0.2
 asynctest==0.13.0
 colorlog==6.10.1

--- a/requirements_generate_data.txt
+++ b/requirements_generate_data.txt
@@ -1,5 +1,5 @@
 --requirement requirements_base.txt
 awscli==1.45.40
-homeassistant==2025.3.0
+homeassistant==2026.6.0
 # https://github.com/aio-libs/aiodns/issues/214
 pycares<5

--- a/requirements_generate_data.txt
+++ b/requirements_generate_data.txt
@@ -1,5 +1,3 @@
 --requirement requirements_base.txt
 awscli==1.45.40
 homeassistant==2026.6.0
-# https://github.com/aio-libs/aiodns/issues/214
-pycares<5


### PR DESCRIPTION
## Summary
Moves the HACS data generation to Python 3.14 and the Home Assistant version its dependencies require. The Python bump alone is not enough: Home Assistant `2026.6.0` requires Python 3.14, and running it on 3.14 pulls in dependency versions that in turn require dropping two now-incompatible pins.

## Changes
- **Python 3.14** — bump `setup-python` from `3.13` to `3.14`:
  - `.github/workflows/generate-hacs-data.yml` (`category-data` and `publish` jobs)
  - `.github/workflows/validate.yml` (data-generation validation job)
- **Home Assistant 2026.6.0** — `requirements_generate_data.txt`: `homeassistant` `2025.3.0` → `2026.6.0` (it requires Python ≥ 3.14.2, and ships `orjson`/`Pillow` versions with cp314 wheels).
- **Drop `aiohttp_cors==0.7.0`** from `requirements_base.txt` — Home Assistant `2026.6.0` depends on `aiohttp_cors==0.8.1`. `aiohttp_cors` is not imported anywhere in HACS; it is a transitive Home Assistant dependency, so removing the explicit pin lets each consumer resolve the right version (min-supported test → `0.7.0`, generator → `0.8.1`).
- **Drop `pycares<5`** from `requirements_generate_data.txt` — Home Assistant `2026.6.0` → `aiodns==4.0.4` requires `pycares>=5.0.0,<6`, so the old workaround pin (for aio-libs/aiodns#214) no longer applies.

## Why the extra bumps
Keeping `homeassistant==2025.3.0` on Python 3.14 fails to install: its pinned `orjson`/`Pillow` have no cp314 wheels and fail to build from source (orjson's vendored PyO3 caps at 3.13; Pillow needs jpeg headers). Bumping Home Assistant fixes that but surfaces the `aiohttp_cors` and `pycares` pin conflicts above, which is why all four changes travel together.

## Verification
The full `requirements_generate_data.txt` dependency tree resolves cleanly for Python 3.14.6 — landing on `homeassistant==2026.6.0`, `orjson==3.11.9`, `pillow==12.2.0`, `pycares==5.0.1`, and `aiohttp_cors` via Home Assistant. Final confirmation is the `Check … with HACS data generation` job in CI.