### PR TITLE
Upgrade action container base image from Python 3.13 to 3.14

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.14-alpine
 WORKDIR /hacs
 
 COPY . /hacs


### PR DESCRIPTION
## Summary
This pull request updates the base image of the HACS container action from Python 3.13 to 3.14.

## Key Changes
- Updated `action/Dockerfile` base image from `python:3.13-alpine` to `python:3.14-alpine`

## Details
Home Assistant `2026.6.0` requires Python 3.14. The container action was still built on `python:3.13-alpine`, which causes the `Check … with HACS Action (local)` validation job to fail once the Home Assistant requirement is bumped (see #5348). Moving the base image to `python:3.14-alpine` builds and runs the action on the required interpreter, with no other changes to the build steps or installed requirements.

This is the companion to #5355 (which bumps the data-generation workflows to 3.14); together they unblock the Home Assistant upgrade in #5348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcXa53YuSxEuTubLA2KRxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcXa53YuSxEuTubLA2KRxk)_