### PR TITLE
Disable credential persistence in GitHub Actions checkout steps

### DIFF
--- a/.github/workflows/action-container.yml
+++ b/.github/workflows/action-container.yml
@@ -33,6 +33,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -225,6 +227,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -59,6 +61,8 @@ jobs:
     steps:
     - name: Checkout the repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Run validation
       run: jq -r -e -c . tests/fixtures/*.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 🛠️ Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/pull_requests_labels.yml
+++ b/.github/workflows/pull_requests_labels.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check the labels
         uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 🛠️ Set up Python 3.13
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 🛠️ Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Test files conflict with running hassfest
       - name: Remove tests
@@ -80,6 +82,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Build Container
         run: |
@@ -109,6 +113,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
## Summary
This pull request adds `persist-credentials: false` configuration to all `actions/checkout` steps across the GitHub Actions workflows. This security-focused change prevents GitHub Actions from persisting credentials in the git configuration during checkout operations.

## Key Changes
- Added `persist-credentials: false` to the `actions/checkout@v7.0.0` step in all workflow files:
  - `.github/workflows/validate.yml` (3 occurrences)
  - `.github/workflows/generate-hacs-data.yml` (2 occurrences)
  - `.github/workflows/lint.yaml` (2 occurrences)
  - `.github/workflows/pytest.yml` (2 occurrences)
  - `.github/workflows/action-container.yml` (1 occurrence)
  - `.github/workflows/publish.yml` (1 occurrence)
  - `.github/workflows/pull_requests_labels.yml` (1 occurrence)

## Implementation Details
- The configuration is added as a `with:` parameter to each checkout action
- This prevents the automatic creation of a `~/.netrc` file with credentials, reducing the attack surface if the runner is compromised
- The change is consistent across all workflows and does not affect the checkout functionality itself

https://claude.ai/code/session_0176au4bLi8UsGpxgKWagCH8