### PR TITLE
Match dashboard resources on exact plugin namespace

### DIFF
--- a/custom_components/hacs/repositories/plugin.py
+++ b/custom_components/hacs/repositories/plugin.py
@@ -210,7 +210,9 @@ class HacsPluginRepository(HacsRepository):
         if not resources.loaded:
             await resources.async_load()
 
-        namespace = self.generate_dashboard_resource_namespace()
+        # The trailing slash matters, without it the namespace of
+        # for example 'button' would also match 'button-card'.
+        namespace = f"{self.generate_dashboard_resource_namespace()}/"
         url = self.generate_dashboard_resource_url()
 
         for entry in resources.async_items():
@@ -237,7 +239,9 @@ class HacsPluginRepository(HacsRepository):
         if not resources.loaded:
             await resources.async_load()
 
-        namespace = self.generate_dashboard_resource_namespace()
+        # The trailing slash matters, without it the namespace of
+        # for example 'button' would also match 'button-card'.
+        namespace = f"{self.generate_dashboard_resource_namespace()}/"
 
         for entry in resources.async_items():
             if entry["url"].startswith(namespace):

--- a/tests/repositories/test_plugin_repository.py
+++ b/tests/repositories/test_plugin_repository.py
@@ -281,6 +281,44 @@ async def test_update_dashboard_resource(
     assert current_urls[0] == after_url
 
 
+async def test_update_dashboard_resource_ignores_prefix_matching_plugins(
+    hass: HomeAssistant,
+    downloaded_plugin_repository: HacsPluginRepository,
+) -> None:
+    """Ensure a plugin with a prefix matching name is not updated."""
+    resource_handler = downloaded_plugin_repository._get_resource_handler()
+    resource_handler.data.clear()
+
+    other_url = "/hacsfiles/plugin-basic-extra/plugin-basic-extra.js?hacstag=42100"
+    await resource_handler.async_create_item({"res_type": "module", "url": other_url})
+
+    await downloaded_plugin_repository.update_dashboard_resources()
+
+    current_urls = [resource["url"]
+                    for resource in resource_handler.async_items()]
+    assert len(current_urls) == 2
+    assert other_url in current_urls
+    assert downloaded_plugin_repository.generate_dashboard_resource_url() in current_urls
+
+
+async def test_remove_dashboard_resource_ignores_prefix_matching_plugins(
+    hass: HomeAssistant,
+    downloaded_plugin_repository: HacsPluginRepository,
+) -> None:
+    """Ensure a plugin with a prefix matching name is not removed."""
+    resource_handler = downloaded_plugin_repository._get_resource_handler()
+    resource_handler.data.clear()
+
+    other_url = "/hacsfiles/plugin-basic-extra/plugin-basic-extra.js?hacstag=42100"
+    await resource_handler.async_create_item({"res_type": "module", "url": other_url})
+
+    await downloaded_plugin_repository.remove_dashboard_resources()
+
+    current_urls = [resource["url"]
+                    for resource in resource_handler.async_items()]
+    assert current_urls == [other_url]
+
+
 async def test_add_dashboard_resource_with_invalid_file_name(
     hass: HomeAssistant,
     downloaded_plugin_repository: HacsPluginRepository,

--- a/tests/snapshots/api-usage/tests/repositories/test_plugin_repositorytest-remove-dashboard-resource-ignores-prefix-matching-plugins.json
+++ b/tests/snapshots/api-usage/tests/repositories/test_plugin_repositorytest-remove-dashboard-resource-ignores-prefix-matching-plugins.json
@@ -1,0 +1,16 @@
+{
+    "tests/repositories/test_plugin_repository.py::test_remove_dashboard_resource_ignores_prefix_matching_plugins": {
+        "https://api.github.com/repos/hacs-test-org/plugin-basic": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/branches/main": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/git/trees/1.0.0": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/releases": 1,
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://raw.githubusercontent.com/hacs-test-org/plugin-basic/1.0.0/README.md": 1,
+        "https://raw.githubusercontent.com/hacs-test-org/plugin-basic/1.0.0/plugin-basic.js": 1
+    }
+}

--- a/tests/snapshots/api-usage/tests/repositories/test_plugin_repositorytest-update-dashboard-resource-ignores-prefix-matching-plugins.json
+++ b/tests/snapshots/api-usage/tests/repositories/test_plugin_repositorytest-update-dashboard-resource-ignores-prefix-matching-plugins.json
@@ -1,0 +1,16 @@
+{
+    "tests/repositories/test_plugin_repository.py::test_update_dashboard_resource_ignores_prefix_matching_plugins": {
+        "https://api.github.com/repos/hacs-test-org/plugin-basic": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/branches/main": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/git/trees/1.0.0": 1,
+        "https://api.github.com/repos/hacs-test-org/plugin-basic/releases": 1,
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://raw.githubusercontent.com/hacs-test-org/plugin-basic/1.0.0/README.md": 1,
+        "https://raw.githubusercontent.com/hacs-test-org/plugin-basic/1.0.0/plugin-basic.js": 1
+    }
+}


### PR DESCRIPTION
## Proposed change

The dashboard resource handling matches Lovelace resource entries with `startswith("/hacsfiles/<name>")`, without a trailing slash. That prefix also matches other plugins whose name starts with the same string.

With for example `button` and `button-card` both installed, updating `button` could rewrite the resource entry of `button-card` to point at `button`'s file, and uninstalling `button` could delete `button-card`'s resource entry instead of its own. Both loops act on the first match and return, so one wrong match corrupts an unrelated plugin.

This change matches on `/hacsfiles/<name>/` (with trailing slash) in both `update_dashboard_resources` and `remove_dashboard_resources`. All HACS managed resource URLs have the form `/hacsfiles/<name>/<file>?hacstag=...`, so legitimate matches are unaffected.

Added tests that set up the collision (only a prefix matching sibling resource present): update must add its own entry and leave the sibling alone, remove must not delete anything. Both fail on the previous code.

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.