### PR TITLE
Adjust concurrency settings for repository updates

### DIFF
--- a/scripts/data/generate_category_data.py
+++ b/scripts/data/generate_category_data.py
@@ -198,7 +198,7 @@ class AdjustedHacs(HacsBase):
             repository_full_name=repository_full_name, category=category, default=True
         )
 
-    @concurrent(concurrenttasks=10, backoff_time=0.4)
+    @concurrent(concurrenttasks=5, backoff_time=1)
     async def concurrent_update_repository(self, repository: HacsRepository) -> None:
         """Update a repository."""
         if repository_has_missing_keys(repository, "update"):


### PR DESCRIPTION
This pull request makes a small adjustment to the concurrency settings for the `concurrent_update_repository` method in `generate_category_data.py`. The number of concurrent tasks has been reduced from 10 to 5, and the backoff time has been increased from 0.4 to 1 second to help reduce load and potential rate limiting issues.

* Reduced concurrency for `concurrent_update_repository` from 10 to 5 and increased backoff time from 0.4 to 1 second in `generate_category_data.py`.