### PR TITLE
Update generate_category_data.py

### DIFF
--- a/scripts/data/generate_category_data.py
+++ b/scripts/data/generate_category_data.py
@@ -198,7 +198,7 @@ class AdjustedHacs(HacsBase):
             repository_full_name=repository_full_name, category=category, default=True
         )
 
-    @concurrent(concurrenttasks=5, backoff_time=1)
+    @concurrent(concurrenttasks=5, backoff_time=1.5)
     async def concurrent_update_repository(self, repository: HacsRepository) -> None:
         """Update a repository."""
         if repository_has_missing_keys(repository, "update"):


### PR DESCRIPTION
This pull request makes a minor adjustment to the concurrency settings in `generate_category_data.py` by increasing the `backoff_time` for the `concurrent_update_repository` method. This change will slightly slow down the retry interval between concurrent tasks, potentially reducing the risk of rate limiting or overloading external services.