### PR TITLE
Reduce concurrency tasks and backoff time

### DIFF
--- a/scripts/data/generate_category_data.py
+++ b/scripts/data/generate_category_data.py
@@ -198,7 +198,7 @@ class AdjustedHacs(HacsBase):
             repository_full_name=repository_full_name, category=category, default=True
         )
 
-    @concurrent(concurrenttasks=5, backoff_time=1.5)
+    @concurrent(concurrenttasks=2, backoff_time=1)
     async def concurrent_update_repository(self, repository: HacsRepository) -> None:
         """Update a repository."""
         if repository_has_missing_keys(repository, "update"):


### PR DESCRIPTION
This pull request makes a minor adjustment to the concurrency settings for the `concurrent_update_repository` method in `generate_category_data.py`. The number of concurrent tasks has been reduced and the backoff time shortened, likely to better manage resource usage or API rate limits.

- Reduced the number of concurrent tasks from 5 to 2 and decreased the backoff time from 1.5 to 1 second in the `@concurrent` decorator for the `concurrent_update_repository` method in `scripts/data/generate_category_data.py`