### PR TITLE
Change cron schedule from every 2 hours to every 4 hours

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -24,7 +24,7 @@ on:
           - template
           - theme
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */4 * * *"
 
 concurrency:
   group: category-data


### PR DESCRIPTION
This pull request makes a small update to the scheduled workflow in `.github/workflows/generate-hacs-data.yml`. The schedule for running the job has been changed from every 2 hours to every 4 hours.