### PR TITLE
Remove RestrictedPython from requirements

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,4 +9,3 @@ pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-snapshot==0.9.0
 pytest-socket==0.8.0
-RestrictedPython==8.3


### PR DESCRIPTION
This pull request removes the `RestrictedPython` dependency from the `requirements_test.txt` file, which will reduce the number of testing dependencies.