### PR TITLE
Limit parallel jobs to one in HACS data generation

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -54,6 +54,7 @@ jobs:
     name: Generate ${{ matrix.category }} data
     strategy:
       fail-fast: true
+      max-parallel: 1
       matrix:
         category: ${{ fromJSON( needs.generate-matrix.outputs.categories )}}
     steps:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change sets the `max-parallel` property to `1` in the job matrix strategy, ensuring that only one job runs at a time for this workflow.