### PR TITLE
Use GitHub App token instead of personal access token for data generation

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -77,10 +77,17 @@ jobs:
           scripts/install/frontend
           scripts/install/pip_packages --requirement requirements_generate_data.txt
 
+      - name: Generate app token
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DATA_GENERATOR_APP_ID }}
+          private-key: ${{ secrets.DATA_GENERATOR_APP_PEM }}
+
       - name: Generate ${{ matrix.category }} data
         run: python3 -m scripts.data.generate_category_data ${{ matrix.category }}
         env:
-          DATA_GENERATOR_TOKEN: ${{ secrets.DATA_GENERATOR_TOKEN }}
+          DATA_GENERATOR_TOKEN: ${{ steps.token.outputs.token }}
           FORCE_REPOSITORY_UPDATE: ${{ inputs.forceRepositoryUpdate }}
 
       - name: Validate output with JQ

--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -81,7 +81,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.DATA_GENERATOR_APP_ID }}
+          client-id: ${{ secrets.DATA_GENERATOR_APP_CLIENT_ID }}
           private-key: ${{ secrets.DATA_GENERATOR_APP_PEM }}
 
       - name: Generate ${{ matrix.category }} data

--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -81,7 +81,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.DATA_GENERATOR_APP_ID }}
+          client-id: ${{ secrets.DATA_GENERATOR_APP_ID }}
           private-key: ${{ secrets.DATA_GENERATOR_APP_PEM }}
 
       - name: Generate ${{ matrix.category }} data


### PR DESCRIPTION
## Summary
This change replaces the use of a static personal access token with a dynamically generated GitHub App token for the data generation workflow, improving security and token management.

## Key Changes
- Added a new step to generate a temporary GitHub App token using the `actions/create-github-app-token` action
- Updated the data generation step to use the dynamically generated token (`${{ steps.token.outputs.token }}`) instead of the static secret (`${{ secrets.DATA_GENERATOR_TOKEN }}`)
- The GitHub App token is created using client ID and private key credentials stored as secrets

## Implementation Details
- The token generation step uses `actions/create-github-app-token@v3.2.0` with pinned commit hash for security
- The generated token is short-lived and scoped to the specific workflow run, reducing the security risk of token exposure
- This approach follows GitHub's recommended best practices for using GitHub Apps in workflows instead of personal access tokens

https://claude.ai/code/session_01SwnRB6MUSuVd412MHEMpA9