### PR TITLE
Add dry-run option to HACS data generation workflow

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -223,7 +223,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: summarize
-    if: ${{ github.repository == 'hacs/integration' && !inputs.dryRun }}
+    if: ${{ github.repository == 'hacs/integration' && !(inputs.dryRun == true || inputs.dryRun == 'true') }}
     name: Publish ${{ matrix.category }} data
     environment: ${{ fromJSON(needs.summarize.outputs.environments)[matrix.category] }}
     strategy:

--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -23,6 +23,11 @@ on:
           - python_script
           - template
           - theme
+      dryRun:
+        description: 'Dry run (generate and summarize only, do not publish)'
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: "0 */4 * * *"
 
@@ -218,7 +223,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: summarize
-    if: github.repository == 'hacs/integration'
+    if: ${{ github.repository == 'hacs/integration' && !inputs.dryRun }}
     name: Publish ${{ matrix.category }} data
     environment: ${{ fromJSON(needs.summarize.outputs.environments)[matrix.category] }}
     strategy:


### PR DESCRIPTION
## Summary
Added a dry-run mode to the HACS data generation workflow that allows generating and summarizing data without publishing it.

## Key Changes
- Added `dryRun` input parameter to the workflow dispatch trigger with a default value of `false`
- Updated the publish job's conditional to skip publishing when dry-run mode is enabled
- The workflow will now generate and summarize data in dry-run mode but skip the actual publication step

## Implementation Details
- The new `dryRun` boolean input is optional and defaults to `false` to maintain backward compatibility
- The publish job condition now checks both the repository name AND the dry-run flag: `github.repository == 'hacs/integration' && !inputs.dryRun`
- This allows developers to test the data generation pipeline without publishing results to production

https://claude.ai/code/session_01QKrjjA6FTMntFdeMyqvouV