### PR TITLE
Improve HACS data generation workflow resilience

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -53,7 +53,7 @@ jobs:
     if: github.repository == 'hacs/integration'
     name: Generate ${{ matrix.category }} data
     strategy:
-      fail-fast: true
+      fail-fast: false
       max-parallel: 1
       matrix:
         category: ${{ fromJSON( needs.generate-matrix.outputs.categories )}}
@@ -125,7 +125,7 @@ jobs:
     name: Summarize
     runs-on: ubuntu-latest
     needs: category-data
-    if: github.repository == 'hacs/integration'
+    if: ${{ always() && github.repository == 'hacs/integration' }}
     outputs:
       changedCategories: ${{ steps.combined.outputs.changedCategories }}
       environments: ${{ steps.combined.outputs.environments }}


### PR DESCRIPTION
## Summary
This PR improves the resilience and reliability of the HACS data generation workflow by allowing jobs to continue even when individual category data generation fails, and ensuring the summarize job always runs to provide a complete status report.

## Key Changes
- **Changed `fail-fast` to `false`** in the `category-data` job matrix strategy
  - Allows all category data generation jobs to complete even if one fails
  - Provides more comprehensive error reporting and data collection across all categories
  
- **Updated `summarize` job condition** to use `always()` function
  - Ensures the summarize job runs regardless of previous job outcomes
  - Allows proper aggregation and reporting of results even when some categories fail
  - Changed from `if: github.repository == 'hacs/integration'` to `if: ${{ always() && github.repository == 'hacs/integration' }}`

## Implementation Details
These changes work together to create a more robust workflow that:
1. Continues processing all categories even if some encounter errors
2. Always generates a summary report of what succeeded and what failed
3. Provides better visibility into workflow health across all categories

https://claude.ai/code/session_01Be78Lv3u6kHrDb73E3zZor