### PR TITLE
Improve publish job reliability with additional condition checks

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -223,7 +223,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: summarize
-    if: ${{ github.repository == 'hacs/integration' && !(inputs.dryRun == true || inputs.dryRun == 'true') }}
+    if: ${{ !cancelled() && needs.summarize.result == 'success' && github.repository == 'hacs/integration' && !(inputs.dryRun == true || inputs.dryRun == 'true') }}
     name: Publish ${{ matrix.category }} data
     environment: ${{ fromJSON(needs.summarize.outputs.environments)[matrix.category] }}
     strategy:


### PR DESCRIPTION
## Summary
Enhanced the conditional logic for the publish job in the HACS data generation workflow to ensure it only runs when appropriate and previous jobs have completed successfully.

## Key Changes
- Added `!cancelled()` check to prevent the publish job from running if the workflow was cancelled
- Added `needs.summarize.result == 'success'` check to ensure the summarize job completed successfully before publishing
- These conditions are now evaluated alongside the existing repository and dry-run checks

## Implementation Details
The publish job now has a more robust condition that:
1. Verifies the workflow wasn't cancelled
2. Confirms the dependent `summarize` job succeeded
3. Maintains the existing checks for the correct repository and non-dry-run execution

This prevents publishing data when upstream jobs fail or are cancelled, improving workflow reliability and data integrity.

https://claude.ai/code/session_01Q5FUicPs2RXVSXVymGNid6