### PR TITLE
Format code and configure ruff linting for scripts directory

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         entry: ruff
         args:
           - check
-        files: ^((action|custom_components|script|tests)/.+)?[^/]+\.py$
+        files: ^((action|custom_components|scripts|tests)/.+)?[^/]+\.py$
 
       - id: ruff-format
         name: Run ruff format
@@ -47,7 +47,7 @@ repos:
         entry: ruff
         args:
           - format
-        files: ^((action|custom_components|script)/.+)?[^/]+\.py$
+        files: ^((action|custom_components|scripts)/.+)?[^/]+\.py$
 
       - id: check-executables-have-shebangs
         name: Check that executables have shebangs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,12 @@ fixable = ["ALL"]
 unfixable = []
 
 
+[tool.ruff.lint.per-file-ignores]
+# CLI/dev utility scripts: printing to stdout, os.path/os.getcwd usage, blocking
+# file I/O in async context, and datetime.utcnow are acceptable here.
+"scripts/**" = ["T201", "PTH118", "PTH109", "ASYNC230", "DTZ003"]
+
+
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true

--- a/scripts/data/common.py
+++ b/scripts/data/common.py
@@ -1,4 +1,5 @@
 """Common helpers for data."""
+
 from __future__ import annotations
 
 import sys

--- a/scripts/data/generate_category_data.py
+++ b/scripts/data/generate_category_data.py
@@ -131,9 +131,7 @@ class AdjustedHacsData(HacsData):
         """Store the repository data."""
         data = {"manifest": {}}
         for key, default in HACS_MANIFEST_KEYS_TO_EXPORT:
-            if (
-                value := getattr(repository.repository_manifest, key, default)
-            ) != default:
+            if (value := getattr(repository.repository_manifest, key, default)) != default:
                 data["manifest"][key] = value
 
         for key, default in REPOSITORY_KEYS_TO_EXPORT:
@@ -167,8 +165,7 @@ class AdjustedHacs(HacsBase):
         self.core.config_path = None
         self.configuration.token = token
         self.data = AdjustedHacsData(hacs=self)
-        self.data_client = HacsDataClient(
-            session=session, client_name="HACS/Generator")
+        self.data_client = HacsDataClient(session=session, client_name="HACS/Generator")
 
         self.github = GitHub(
             token,
@@ -227,17 +224,20 @@ class AdjustedHacs(HacsBase):
                     for release in releases:
                         if release.draft:
                             repository.logger.warning(
-                                "%s Found draft %s", repository.string, release.tag_name)
+                                "%s Found draft %s", repository.string, release.tag_name
+                            )
 
                         elif release.prerelease:
                             repository.logger.info(
-                                "%s Found prerelease %s", repository.string, release.tag_name)
+                                "%s Found prerelease %s", repository.string, release.tag_name
+                            )
                             if repository.data.prerelease is None:
                                 repository.data.prerelease = release.tag_name
 
                         else:
                             repository.logger.info(
-                                "%s Found release %s", repository.string, release.tag_name)
+                                "%s Found release %s", repository.string, release.tag_name
+                            )
                             repository.data.releases = True
                             repository.releases.objects = releases
                             repository.data.published_tags = [
@@ -258,8 +258,7 @@ class AdjustedHacs(HacsBase):
                         endpoint=f"/repos/{repository.data.full_name}/releases/latest",
                         etag=repository.data.etag_releases,
                     )
-                    response.data = GitHubReleaseModel(
-                        response.data) if response.data else None
+                    response.data = GitHubReleaseModel(response.data) if response.data else None
 
                     if (releases := response.data) is not None:
                         repository.data.releases = True
@@ -287,8 +286,7 @@ class AdjustedHacs(HacsBase):
                 )
             except GitHubNotFoundException:
                 repository.data.releases = False
-                repository.logger.info(
-                    "%s No releases found", repository.string)
+                repository.logger.info("%s No releases found", repository.string)
             except GitHubException as exception:
                 repository.data.releases = False
                 repository.logger.error("%s %s", repository.string, exception)
@@ -377,8 +375,7 @@ class AdjustedHacs(HacsBase):
                 continue
             repository = self.repositories.get_by_full_name(repo)
             if repository is not None:
-                self.queue.add(self.concurrent_update_repository(
-                    repository=repository))
+                self.queue.add(self.concurrent_update_repository(repository=repository))
                 continue
 
             self.queue.add(
@@ -456,8 +453,7 @@ class AdjustedHacs(HacsBase):
 async def generate_category_data(category: str, repository_name: str = None):
     """Generate data."""
     async with ClientSession() as session:
-        hacs = AdjustedHacs(
-            session=session, token=os.getenv("DATA_GENERATOR_TOKEN"))
+        hacs = AdjustedHacs(session=session, token=os.getenv("DATA_GENERATOR_TOKEN"))
         os.makedirs(os.path.join(OUTPUT_DIR, category), exist_ok=True)
         os.makedirs(os.path.join(OUTPUT_DIR, "diff"), exist_ok=True)
         force = os.environ.get("FORCE_REPOSITORY_UPDATE") == "True"
@@ -497,11 +493,7 @@ async def generate_category_data(category: str, repository_name: str = None):
             )
 
         did_raise = False
-        if (
-            not updated_data
-            or len(updated_data) == 0
-            or not isinstance(updated_data, dict)
-        ):
+        if not updated_data or len(updated_data) == 0 or not isinstance(updated_data, dict):
             print_error_and_exit("Updated data is empty", category)
             did_raise = True
 
@@ -518,8 +510,7 @@ async def generate_category_data(category: str, repository_name: str = None):
             print_error_and_exit(f"Invalid data: {errors}", category)
 
         if did_raise:
-            print_error_and_exit(
-                "Validation did raise but did not exit!", category)
+            print_error_and_exit("Validation did raise but did not exit!", category)
             sys.exit(1)  # Fallback, should not be reached
 
         with open(
@@ -563,10 +554,7 @@ async def generate_category_data(category: str, repository_name: str = None):
         ) as data_file:
             json.dump(
                 {
-                    i: {
-                        k: v
-                        for k, v in d.items() if k not in COMPARE_IGNORE
-                    }
+                    i: {k: v for k, v in d.items() if k not in COMPARE_IGNORE}
                     for i, d in current_data.items()
                 },
                 data_file,
@@ -582,10 +570,7 @@ async def generate_category_data(category: str, repository_name: str = None):
         ) as data_file:
             json.dump(
                 {
-                    i: {
-                        k: v
-                        for k, v in d.items() if k not in COMPARE_IGNORE
-                    }
+                    i: {k: v for k, v in d.items() if k not in COMPARE_IGNORE}
                     for i, d in updated_data.items()
                 },
                 data_file,

--- a/scripts/data/validate_category_data.py
+++ b/scripts/data/validate_category_data.py
@@ -1,4 +1,5 @@
 """Validate HACS V2 data."""
+
 from __future__ import annotations
 
 import asyncio
@@ -48,17 +49,14 @@ async def validate_category_data(category: str, file_path: str) -> None:
 
         if category == "integration" and HACS_REPOSITORY_ID not in contents:
             did_raise = True
-            print_error_and_exit(
-                "HACS is missing...", category, file_path
-            )
+            print_error_and_exit("HACS is missing...", category, file_path)
 
         if did_raise:
             print_error_and_exit("Validation did raise but did not exit!", category, file_path)
             sys.exit(1)  # Fallback, should not be reached
 
         print(
-            f"All {len(contents)} entries for the "
-            f"{category} category in {target_path} are valid."
+            f"All {len(contents)} entries for the {category} category in {target_path} are valid."
         )
 
 

--- a/scripts/update/default_repositories.py
+++ b/scripts/update/default_repositories.py
@@ -1,4 +1,5 @@
 """Update the shipped default repositories data file."""
+
 import json
 import os
 import sys

--- a/scripts/update/manifest.py
+++ b/scripts/update/manifest.py
@@ -1,4 +1,5 @@
 """Update the manifest file."""
+
 import json
 import os
 from pathlib import Path


### PR DESCRIPTION
## Summary
This PR applies code formatting improvements and updates the ruff linting configuration to properly handle the `scripts/` directory with appropriate rule exceptions.

## Key Changes
- **Code Formatting**: Applied consistent line length formatting throughout `scripts/data/generate_category_data.py` and `scripts/data/validate_category_py`, collapsing multi-line statements where appropriate to improve readability
- **Ruff Configuration**: Added per-file-ignores configuration in `pyproject.toml` to exclude specific linting rules for scripts (T201, PTH118, PTH109, ASYNC230, DTZ003) that are acceptable in CLI/dev utility scripts
- **Pre-commit Configuration**: Updated `.github/pre-commit-config.yaml` to include `scripts/` directory in ruff check and format file patterns (changed `script` to `scripts`)
- **Module Docstrings**: Added blank lines after module docstrings in `scripts/data/common.py`, `scripts/data/validate_category_data.py`, `scripts/update/default_repositories.py`, and `scripts/update/manifest.py` for PEP 257 compliance

## Notable Details
- The formatting changes maintain functional equivalence while improving code consistency
- The ruff configuration exceptions are appropriate for utility scripts that may use `print()` statements, `os.path` operations, and blocking I/O
- All changes align with the project's existing code style and linting standards

https://claude.ai/code/session_01YYn1cR8ELdBU4Ko4c4WsSd