### PR TITLE
Fix device lookup and validation tests against Home Assistant dev

### DIFF
--- a/custom_components/hacs/repositories/base.py
+++ b/custom_components/hacs/repositories/base.py
@@ -1297,13 +1297,18 @@ class HacsRepository:
 
     async def async_remove_entity_device(self) -> None:
         """Remove the entity device."""
-        device_registry: dr.DeviceRegistry = dr.async_get(hass=self.hacs.hass)
-        device = device_registry.async_get_device(identifiers={(DOMAIN, str(self.data.id))})
-
-        if device is None:
+        if (config_entry := self.hacs.configuration.config_entry) is None:
             return
 
-        device_registry.async_remove_device(device_id=device.id)
+        device_registry: dr.DeviceRegistry = dr.async_get(hass=self.hacs.hass)
+        identifier = (DOMAIN, str(self.data.id))
+
+        # Looked up through our own config entry, since identifiers are only
+        # guaranteed to be unique within a single config entry.
+        for device in dr.async_entries_for_config_entry(device_registry, config_entry.entry_id):
+            if identifier in device.identifiers:
+                device_registry.async_remove_device(device_id=device.id)
+                return
 
     def version_to_download(self) -> str:
         """Determine which version to download."""

--- a/tests/action/test_hacs_action_integration.py
+++ b/tests/action/test_hacs_action_integration.py
@@ -5,7 +5,13 @@ from unittest import mock
 
 import pytest
 
-from tests.common import TOKEN, MockedResponse, ResponseMocker, current_function_name
+from tests.common import (
+    TOKEN,
+    MockedResponse,
+    ResponseMocker,
+    current_function_name,
+    normalize_voluptuous_paths,
+)
 from tests.conftest import SnapshotFixture
 
 
@@ -116,10 +122,12 @@ async def test_hacs_action_integration(
         "\n") if " <" in line]
 
     snapshots.assert_match(
-        "\n".join(
-            splitlines[0:2] +
-            sorted(splitlines[2:-2]) + splitlines[-2:]
-            + [capsys.readouterr().out]
+        normalize_voluptuous_paths(
+            "\n".join(
+                splitlines[0:2] +
+                sorted(splitlines[2:-2]) + splitlines[-2:]
+                + [capsys.readouterr().out]
+            )
         ),
         f"action/{current_function_name()}/{request.node.callspec.id}.log",
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from inspect import currentframe
 import json as json_func
 import os
+import re
 from types import NoneType
 from typing import Any, TypedDict
 from unittest.mock import AsyncMock, patch
@@ -136,6 +137,25 @@ def category_test_data_parametrized(
 def current_function_name():
     """Return the name of the current function."""
     return currentframe().f_back.f_code.co_name
+
+
+# voluptuous 0.16 reports the offending path as "at 'a.b'" where older releases used
+# " for dictionary value @ data['a']['b']". HACS is tested against both, so the legacy
+# form is rewritten to keep snapshots version independent. Drop this once the minimum
+# supported Home Assistant version ships voluptuous 0.16 or newer.
+_LEGACY_VOLUPTUOUS_PATH = re.compile(
+    r"(?: for dictionary value)? @ data((?:\['[^']+'\])+)",
+)
+
+
+def normalize_voluptuous_paths(text: str) -> str:
+    """Rewrite legacy voluptuous error paths into the current format."""
+
+    def _rewrite(match: re.Match[str]) -> str:
+        keys = re.findall(r"\['([^']+)'\]", match.group(1))
+        return f" at '{'.'.join(keys)}'"
+
+    return _LEGACY_VOLUPTUOUS_PATH.sub(_rewrite, text)
 
 
 def safe_json_dumps(data: dict | list) -> str:

--- a/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_documentation.log
@@ -8,7 +8,7 @@
 <Validation description> completed
 <Validation hacsjson> completed
 <Validation information> completed
-<Validation integration_manifest> failed:  invalid url for dictionary value @ data['documentation']. Got None (More info: https://hacs.xyz/docs/publish/include#check-manifest )
+<Validation integration_manifest> failed:  invalid url at 'documentation'. Got None (More info: https://hacs.xyz/docs/publish/include#check-manifest )
 <Validation issues> completed
 <Validation license> completed
 <Validation topics> completed

--- a/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
+++ b/tests/snapshots/action/test_hacs_action_integration/bad_issue_tracker.log
@@ -8,7 +8,7 @@
 <Validation description> completed
 <Validation hacsjson> completed
 <Validation information> completed
-<Validation integration_manifest> failed:  invalid url for dictionary value @ data['issue_tracker']. Got None (More info: https://hacs.xyz/docs/publish/include#check-manifest )
+<Validation integration_manifest> failed:  invalid url at 'issue_tracker'. Got None (More info: https://hacs.xyz/docs/publish/include#check-manifest )
 <Validation issues> completed
 <Validation license> completed
 <Validation topics> completed

--- a/tests/utils/test_validate.py
+++ b/tests/utils/test_validate.py
@@ -79,7 +79,7 @@ def test_hacs_manifest_json_schema():
         },
     )
 
-    with pytest.raises(Invalid, match="extra keys not allowed"):
+    with pytest.raises(Invalid, match=r"extra keys not allowed|not a valid option"):
         hacs_json_schema({"name": "My awesome thing", "not": "valid"})
 
     with pytest.raises(Invalid, match="Value 'NOT_VALID' is not in"):
@@ -103,7 +103,7 @@ def test_integration_json_schema():
     assert integration_json_schema(base_data)["version"] == AwesomeVersion(1.2)
     assert integration_json_schema(base_data) == base_data
 
-    with pytest.raises(Invalid, match="expected str for dictionary value"):
+    with pytest.raises(Invalid, match="expected str"):
         integration_json_schema({**base_data, "domain": None})
 
 


### PR DESCRIPTION
The Home Assistant dev test job has been red on `main` for a while, which made every open pull request look broken. Two unrelated things landed in Home Assistant dev.

## Deprecated device registry lookup

Home Assistant deprecated `device_registry.async_get_device` (breaks in 2027.8.0), because identifiers and connections are no longer unique across config entries. The call now goes through `report_usage`, which raises `RuntimeError: Frame helper not set up` in the test environment. That surfaced as a bare `assert False == True` in `test_remove_repository`, and since the suite runs with `-x`, every pull request stopped right there.

The device is now looked up through our own config entry with `dr.async_entries_for_config_entry`. That helper is present and undeprecated in both the minimum supported version and dev, so no version gate is needed. Identifiers are unique within a single config entry, which is exactly the guarantee we need here.

## voluptuous 0.16

Home Assistant dev pins voluptuous 0.16, the minimum supported version still has 0.15.2. The error wording changed: `... for dictionary value @ data[a][b]` became `... at 'a.b'`, and `extra keys not allowed` became `not a valid option`. That breaks two schema tests and two action snapshots. These were invisible until now, hidden behind the failure above.

The legacy wording is normalized in the action snapshots, and the schema tests accept both forms. The normalizer is marked for removal once the minimum supported Home Assistant version ships voluptuous 0.16 or newer.

## Verification

Ran the full suite against both ends of the supported range:

- Home Assistant 2025.3.0 on Python 3.13: 429 passed
- Home Assistant 2026.9.0.dev0 on Python 3.14: 429 passed

All six `test_remove_repository` cases reproduce on unmodified `main` with Home Assistant dev, and pass with this change.