### PR TITLE
Add generated integration domain registry

### DIFF
--- a/.github/workflows/generate-hacs-data.yml
+++ b/.github/workflows/generate-hacs-data.yml
@@ -93,6 +93,9 @@ jobs:
         run: |
           jq -c . outputdata/${{ matrix.category }}/data.json
           jq -c . outputdata/${{ matrix.category }}/repositories.json
+          if [[ "${{ matrix.category }}" == "integration" ]]; then
+            jq -e 'type == "array" and all(.[]; type == "string" and length > 0) and . == (sort | unique)' outputdata/integration/domains.json
+          fi
 
       - name: Validate output with schema
         run: |
@@ -261,6 +264,9 @@ jobs:
         run: |
           jq -c . outputdata/${{ matrix.category }}/data.json
           jq -c . outputdata/${{ matrix.category }}/repositories.json
+          if [[ "${{ matrix.category }}" == "integration" ]]; then
+            jq -e 'type == "array" and all(.[]; type == "string" and length > 0) and . == (sort | unique)' outputdata/integration/domains.json
+          fi
 
       - name: Validate output with schema
         run: |
@@ -283,6 +289,15 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CF_BUST_CACHE_TOKEN }}" \
             -H "Content-Type: application/json" \
             --data '{"files": ["https:\/\/data-v2.hacs.xyz\/${{ matrix.category }}\/data.json", "https:\/\/data-v2.hacs.xyz\/${{ matrix.category }}\/repositories.json"]}'
+
+      - name: Bust Cloudflare integration domain registry cache
+        if: matrix.category == 'integration'
+        run: |
+          curl --silent --show-error --fail -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CF_BUST_CACHE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"files": ["https:\/\/data-v2.hacs.xyz\/integration\/domains.json"]}'
 
   notify_on_failure:
     runs-on: ubuntu-latest

--- a/scripts/data/generate_category_data.py
+++ b/scripts/data/generate_category_data.py
@@ -547,6 +547,18 @@ async def generate_category_data(category: str, repository_name: str = None):
                 sort_keys=True,
             )
 
+        if category == "integration":
+            with open(
+                os.path.join(OUTPUT_DIR, category, "domains.json"),
+                mode="w",
+                encoding="utf-8",
+            ) as domains_file:
+                json.dump(
+                    sorted({repository["domain"] for repository in updated_data.values()}),
+                    domains_file,
+                    separators=(",", ":"),
+                )
+
         with open(
             os.path.join(OUTPUT_DIR, "diff", f"{category}_before.json"),
             mode="w",

--- a/tests/scripts/data/test_generate_category_data.py
+++ b/tests/scripts/data/test_generate_category_data.py
@@ -123,6 +123,10 @@ async def test_generate_category_data(
                 category_test_data['category']}/repositories.json",
         )
 
+    if category_test_data["category"] == "integration":
+        with open(f"{OUTPUT_DIR}/integration/domains.json", encoding="utf-8") as file:
+            assert json.load(file) == ["example"]
+
     with open(
         f"{OUTPUT_DIR}/summary.json",
         encoding="utf-8",


### PR DESCRIPTION
## Summary

- publish a compact, sorted, and deduplicated list of default HACS integration domains as `integration/domains.json`
- validate the registry during both generation and publication
- purge the Cloudflare cache for the registry after publication
- cover generation and duplicate removal in the existing data-generator tests

## Motivation

Home Assistant Analytics currently filters public custom-integration statistics through the legacy `home-assistant/brands` domain list. Custom integrations can now ship branding locally, so newer integrations are no longer guaranteed to enter that list. This leaves valid integrations absent from the public Analytics dataset.

The Analytics discussion suggested using presence in HACS as the trust boundary instead of removing the guardrail entirely:

- https://github.com/home-assistant/analytics.home-assistant.io/issues/1094
- https://github.com/home-assistant/analytics.home-assistant.io/pull/1091

HACS already publishes the required domain information in `integration/data.json`. This change exposes the same validated data through a small, purpose-specific endpoint:

```json
["domain_a","domain_b"]
```

This does not add analytics or tracking to HACS and does not change HACS runtime or UI behavior. It only publishes a stable registry derived from the existing default integration dataset. Home Assistant Analytics can consume this endpoint in a separate change and union it with the legacy Brands list.

## Why a dedicated endpoint?

Analytics could technically parse the existing `integration/data.json`, but that file is repository metadata rather than a purpose-specific domain-registry contract. It is currently about 2.1 MB, while the derived domain list is approximately 47 KB.

Publishing `domains.json` keeps downstream consumers independent of the internal repository-data structure and gives HACS explicit control over the definition of a trusted default integration. The file is generated from the same validated data, so it introduces no additional source of truth or maintenance burden.

The intended Analytics behavior is:

```text
trusted custom domains = legacy Brands domains + default HACS integration domains
```

Unknown custom domains would remain excluded. This restores visibility for reviewed HACS integrations without removing the existing publication guardrail.

## Future possibilities

A stable domain registry would allow ecosystem tools to associate reviewed HACS integrations with other public, domain-indexed datasets without depending on HACS's full repository-metadata format.

If Home Assistant Analytics adopts this registry, downstream tools could combine release activity with anonymized, opt-in installation reporting, store historical snapshots, and show weekly or monthly adoption trends. The registry itself would contain no usage data and would not change HACS's privacy model.

## Validation

- `python -m pytest tests/scripts/data/test_generate_category_data.py --no-cov -q` — 24 passed
- `ruff check scripts/data/generate_category_data.py tests/scripts/data/test_generate_category_data.py`
- `ruff format --check scripts/data/generate_category_data.py`
- workflow YAML parse and JSON contract checks