### PR TITLE
Use the brands proxy for update entity pictures when available

### DIFF
--- a/custom_components/hacs/update.py
+++ b/custom_components/hacs/update.py
@@ -76,6 +76,12 @@ class HacsRepositoryUpdateEntity(HacsRepositoryEntity, UpdateEntity):
         ):
             return None
 
+        if "brands" in self.hass.config.components:
+            # Home Assistant 2026.3+ proxies brand images locally, which also serves
+            # the assets custom integrations ship in their own brand/ directory.
+            # The frontend adds the required access token to /api/brands/ paths.
+            return f"/api/brands/integration/{self.repository.data.domain}/icon.png"
+
         return f"https://brands.home-assistant.io/_/{self.repository.data.domain}/icon.png"
 
     async def async_install(self, version: str | None, backup: bool, **kwargs: Any) -> None:

--- a/tests/snapshots/api-usage/tests/test_updatetest-update-entity-picture-brands-proxy-hacs-test-org-integration-basic.json
+++ b/tests/snapshots/api-usage/tests/test_updatetest-update-entity-picture-brands-proxy-hacs-test-org-integration-basic.json
@@ -1,0 +1,17 @@
+{
+    "tests/test_update.py::test_update_entity_picture[brands_proxy-hacs-test-org/integration-basic]": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://data-v2.hacs.xyz/appdaemon/data.json": 1,
+        "https://data-v2.hacs.xyz/critical/data.json": 1,
+        "https://data-v2.hacs.xyz/integration/data.json": 1,
+        "https://data-v2.hacs.xyz/plugin/data.json": 1,
+        "https://data-v2.hacs.xyz/python_script/data.json": 1,
+        "https://data-v2.hacs.xyz/removed/data.json": 1,
+        "https://data-v2.hacs.xyz/template/data.json": 1,
+        "https://data-v2.hacs.xyz/theme/data.json": 1
+    }
+}

--- a/tests/snapshots/api-usage/tests/test_updatetest-update-entity-picture-cdn-hacs-test-org-integration-basic.json
+++ b/tests/snapshots/api-usage/tests/test_updatetest-update-entity-picture-cdn-hacs-test-org-integration-basic.json
@@ -1,0 +1,17 @@
+{
+    "tests/test_update.py::test_update_entity_picture[cdn-hacs-test-org/integration-basic]": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1,
+        "https://data-v2.hacs.xyz/appdaemon/data.json": 1,
+        "https://data-v2.hacs.xyz/critical/data.json": 1,
+        "https://data-v2.hacs.xyz/integration/data.json": 1,
+        "https://data-v2.hacs.xyz/plugin/data.json": 1,
+        "https://data-v2.hacs.xyz/python_script/data.json": 1,
+        "https://data-v2.hacs.xyz/removed/data.json": 1,
+        "https://data-v2.hacs.xyz/template/data.json": 1,
+        "https://data-v2.hacs.xyz/theme/data.json": 1
+    }
+}

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity_registry import async_get as async_get_entity_
 import pytest
 
 from custom_components.hacs.const import DOMAIN
+from custom_components.hacs.enums import HacsCategory
 
 from tests.common import (
     CategoryTestData,
@@ -95,4 +96,41 @@ async def test_update_entity_state(
         safe_json_dumps({"initial_state": initial_state,
                         "updated_state": updated_state}),
         f"{category_test_data['repository']}/test_update_entity_state.json",
+    )
+
+
+@pytest.mark.parametrize(
+    "category_test_data",
+    category_test_data_parametrized(categories=[HacsCategory.INTEGRATION]),
+)
+@pytest.mark.parametrize("brands_loaded", [False, True], ids=["cdn", "brands_proxy"])
+async def test_update_entity_picture(
+    hass: HomeAssistant,
+    setup_integration: Generator,
+    category_test_data: CategoryTestData,
+    brands_loaded: bool,
+):
+    """Test the entity picture follows the availability of the brands proxy."""
+    hacs = get_hacs(hass)
+    repo = hacs.repositories.get_by_full_name(category_test_data["repository"])
+
+    assert repo is not None
+
+    repo.data.installed = True
+    repo.data.installed_version = category_test_data["version_base"]
+
+    if brands_loaded:
+        hass.config.components.add("brands")
+
+    await hass.config_entries.async_reload(hacs.configuration.config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    er = async_get_entity_registry(hass)
+    entity_id = er.async_get_entity_id("update", DOMAIN, repo.data.id)
+    state = hass.states.get(entity_id)
+
+    assert state.attributes["entity_picture"] == (
+        f"/api/brands/integration/{repo.data.domain}/icon.png"
+        if brands_loaded
+        else f"https://brands.home-assistant.io/_/{repo.data.domain}/icon.png"
     )


### PR DESCRIPTION
Hi :)

## Proposed change

Since Home Assistant 2026.3, brand images are served by a local, token-gated proxy at `/api/brands/integration/{domain}/{image}` ([announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api/)), which resolves `custom_components/<domain>/brand/` before falling back to the CDN. `HacsRepositoryUpdateEntity.entity_picture` still points at the CDN, so update entities of integrations that ship their own `brand/` folder show the placeholder image in the updates list.

Core's own `UpdateEntity` returns `/api/brands/integration/{platform}/icon.png` by default ([`update/__init__.py`](https://github.com/home-assistant/core/blob/568136f8406f2cd04234e3d0f436ce2983a4564a/homeassistant/components/update/__init__.py#L315-L321)); this makes HACS do the same for the repository's domain when the proxy exists.

This picks up where #5228 and #5339 stopped, and addresses the two points raised in their reviews:

- **Cores without the proxy.** The proxy path is only returned when the `brands` integration is loaded (`"brands" in hass.config.components`). `brands` is a bootstrap core integration on every 2026.3+ install ([`bootstrap.py`](https://github.com/home-assistant/core/blob/568136f8406f2cd04234e3d0f436ce2983a4564a/homeassistant/bootstrap.py#L222)) and does not exist before it, so this detects the endpoint itself rather than a version number. Older cores keep the CDN URL unchanged.
- **Authentication.** The path is returned without a token on purpose, exactly like core's update entities: the frontend appends the rotating brands token to any `/api/brands/` URL when it renders an entity picture ([`state-badge.ts`](https://github.com/home-assistant/frontend/blob/241b8c5771cb5e77f1088cc13095c8e2626bd160/src/components/entity/state-badge.ts#L211-L220) via `hass.hassUrl()` → `addBrandsAuth`). A token baked into the attribute would expire after an hour.

Feature detection also keeps the existing snapshots identical on both CI legs, since the test harness does not load `brands` on either.

The dashboard icons are handled separately in hacs/frontend#949.

## Verification

- New `test_update_entity_picture`, parametrised over both states, asserts the CDN URL without `brands` and the proxy path with it.
- Full suite: 431 passed on Home Assistant 2025.3.0 / Python 3.13. No existing snapshot changed.
- `ruff check` clean.
- Checked against a live Home Assistant 2026.9.0 instance running HACS: `brands` is in `hass.config.components`, and for two downloaded custom integrations shipping `brand/icon.png` but absent from `home-assistant/brands`, `/api/brands/integration/{domain}/icon.png` serves the real icon (200) both with the bearer token and with the `brands/access_token` query token, while the current CDN `entity_picture` answers 200 with the placeholder. Without a token the proxy answers 403.

Related: #5171, #5223, #5228, #5339.

Cheers ;)

ReikanYsora / Jérôme

