### PR TITLE
Delete stale restart_required issues on startup

### DIFF
--- a/custom_components/hacs/base.py
+++ b/custom_components/hacs/base.py
@@ -33,7 +33,12 @@ from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+    async_get as async_get_issue_registry,
+)
 from homeassistant.loader import Integration
 from homeassistant.util import dt
 
@@ -596,9 +601,24 @@ class HacsBase:
 
         self.repositories.register(repository, default)
 
+    @callback
+    def async_delete_stale_restart_issues(self) -> None:
+        """Delete restart_required issues left over from a previous run.
+
+        The issues are created when a download requires a restart to take
+        effect. Reaching this point means Home Assistant has restarted, so any
+        such issue from a previous run is resolved and its entry would
+        otherwise be kept in the issue registry forever.
+        """
+        issue_registry = async_get_issue_registry(self.hass)
+        for issue in list(issue_registry.issues.values()):
+            if issue.domain == DOMAIN and issue.issue_id.startswith("restart_required_"):
+                async_delete_issue(self.hass, DOMAIN, issue.issue_id)
+
     async def startup_tasks(self, _=None) -> None:
         """Tasks that are started after setup."""
         self.set_stage(HacsStage.STARTUP)
+        self.async_delete_stale_restart_issues()
         await self.async_load_hacs_from_github()
 
         if critical := await async_load_from_store(self.hass, "critical"):

--- a/tests/hacsbase/test_hacs.py
+++ b/tests/hacsbase/test_hacs.py
@@ -1,7 +1,9 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+from homeassistant.helpers import issue_registry as ir
 import pytest
 
 from custom_components.hacs.base import HacsRepositories
+from custom_components.hacs.const import DOMAIN
 from custom_components.hacs.enums import HacsCategory
 
 
@@ -57,3 +59,44 @@ async def test_add_remove_repository(hacs, repository, tmpdir):
 
     # Verify second removal does not raise
     hacs.repositories.unregister(repository)
+
+
+async def test_delete_stale_restart_issues(hacs):
+    issue_registry = ir.async_get(hacs.hass)
+
+    ir.async_create_issue(
+        hass=hacs.hass,
+        domain=DOMAIN,
+        issue_id="restart_required_1337_tags/1.0.0",
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="restart_required",
+    )
+    ir.async_create_issue(
+        hass=hacs.hass,
+        domain=DOMAIN,
+        issue_id="removed_1337",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="removed",
+    )
+    ir.async_create_issue(
+        hass=hacs.hass,
+        domain="other",
+        issue_id="restart_required_1337_tags/1.0.0",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="restart_required",
+    )
+
+    hacs.async_delete_stale_restart_issues()
+
+    # The restart has already happened, so the issue is no longer relevant
+    assert issue_registry.async_get_issue(DOMAIN, "restart_required_1337_tags/1.0.0") is None
+
+    # Issues of other types, and issues from other domains, are left alone
+    assert issue_registry.async_get_issue(DOMAIN, "removed_1337") is not None
+    assert issue_registry.async_get_issue("other", "restart_required_1337_tags/1.0.0") is not None
+
+    # Safe to run when there is nothing to delete
+    hacs.async_delete_stale_restart_issues()

--- a/tests/snapshots/api-usage/tests/hacsbase/test_hacstest-delete-stale-restart-issues.json
+++ b/tests/snapshots/api-usage/tests/hacsbase/test_hacstest-delete-stale-restart-issues.json
@@ -1,0 +1,9 @@
+{
+    "tests/hacsbase/test_hacs.py::test_delete_stale_restart_issues": {
+        "https://api.github.com/repos/hacs/integration": 1,
+        "https://api.github.com/repos/hacs/integration/contents/custom_components/hacs/manifest.json": 1,
+        "https://api.github.com/repos/hacs/integration/contents/hacs.json": 1,
+        "https://api.github.com/repos/hacs/integration/git/trees/main": 1,
+        "https://api.github.com/repos/hacs/integration/releases": 1
+    }
+}


### PR DESCRIPTION
## Summary

`restart_required` repair issues are created in `HacsIntegrationRepository.async_post_installation`, but nothing ever deletes them. The issue id embeds the ref (`restart_required_{id}_{ref}`), so every download mints a **new** id rather than reusing an existing one, and the entries accumulate in `.storage/repairs.issue_registry` indefinitely.

This adds a sweep in `startup_tasks`. Reaching that point means Home Assistant has restarted, so any `restart_required` issue from a previous run is by definition already resolved.

## Why this is not visible today

These issues are not persistent, so core keeps them across a restart as **inactive** entries with their fields stripped (`IssueRegistry._async_load` sets `active=False`, and `IssueEntry.to_json` writes the stripped row back). That is intended core behaviour, so the fix belongs here rather than in core.

The effect is that the rows never appear in the repairs UI or the websocket API, yet they are re-serialised to storage on every save. The growth is completely silent.

On my own installation there were **122** of them, dating back 15 months:

```
TOTAL ROWS: 195
by domain: [('hacs', 123), ('mqtt', 61), ('template', 3), ...]
restart_required rows: 122
created min/max: 2025-06-10 .. 2026-09-09
```

The repairs API reported 4 issues and none of these, even including dismissed ones.

## Note on #4403

[#4403](https://github.com/hacs/integration/pull/4403) also called `async_delete_issue` on these issues and was rejected, so I want to be explicit that this is a different change.

That PR let users **dismiss a pending restart without restarting**, which is the behaviour you objected to: the code is still loaded until a restart, so the warning has to stand. This PR does not add any way to dismiss anything, and does not touch the repair flow. It only deletes issues *after* a restart has already happened, at which point the warning has served its purpose. Behaviour before a restart is unchanged.

If the accumulation is considered acceptable, feel free to close this — but the leak is unbounded and users cannot see or clear it themselves.

## Testing

- New test `test_delete_stale_restart_issues` covers the deletion, that `removed_*` issues and other domains' issues are left alone, and that a second run is a no-op.
- Full suite: 429 passed. `tests/repositories/test_update_repository.py::test_update_repository_entity_no_update` fails, but it fails identically on an unmodified checkout of `adb7d83`, so it is unrelated to this change.
- `ruff check`, `ruff format --check` and `isort --check-only` all clean.
